### PR TITLE
Replaced @ with np.dot()

### DIFF
--- a/p5/pmath/vector.py
+++ b/p5/pmath/vector.py
@@ -318,7 +318,7 @@ class Vector(Point):
         :rtype: float
 
         """
-        return np.arccos( (self @ other) / (self.magnitude * other.magnitude))
+        return np.arccos((np.dot(self, other)) / (self.magnitude * other.magnitude))
 
     @property
     def magnitude(self):
@@ -342,7 +342,7 @@ class Vector(Point):
             Vector(0.29, 0.43, 0.86)
 
         """
-        return np.sqrt(self @ self)
+        return np.sqrt(np.dot(self, self))
 
     @magnitude.setter
     def magnitude(self, new_magnitude):
@@ -352,7 +352,7 @@ class Vector(Point):
     @property
     def magnitude_sq(self):
         """The squared magnitude of the vector."""
-        return self @ self
+        return np.dot(self, self)
 
     @magnitude_sq.setter
     def magnitude_sq(self, new_magnitude_sq):


### PR DESCRIPTION
Fixes #18 .

Replaced all `@` operator with `np.dot` since `@` operator was introduced from python3.5. 
There are still some issues while running the code:

```python 
    from p5 import *
  File "/Users/arihantparsoya/Documents/p5/p5/__init__.py", line 19, in <module>
    from .sketch import *
  File "/Users/arihantparsoya/Documents/p5/p5/sketch/__init__.py", line 19, in <module>
    from .base import *
  File "/Users/arihantparsoya/Documents/p5/p5/sketch/base.py", line 29, in <module>
    from ..opengl import renderer
  File "/Users/arihantparsoya/Documents/p5/p5/opengl/__init__.py", line 19, in <module>
    from .renderer import *
  File "/Users/arihantparsoya/Documents/p5/p5/opengl/renderer.py", line 33, in <module>
    from ..pmath import matrix
  File "/Users/arihantparsoya/Documents/p5/p5/pmath/__init__.py", line 22, in <module>
    from .curves import *
  File "/Users/arihantparsoya/Documents/p5/p5/pmath/curves.py", line 46
    ret_value = func(*new_args, parameter, **kwargs)
                                       ^
SyntaxError: only named arguments may follow *expression
```