### PR TITLE
Fixed issue #16: negative mouse_x and mouse_y values.

### DIFF
--- a/p5/sketch/events.py
+++ b/p5/sketch/events.py
@@ -203,8 +203,8 @@ class MouseEvent(Event):
     def _update_globals(self):
         builtins.pmouse_x = builtins.mouse_x
         builtins.pmouse_y = builtins.mouse_y
-        builtins.mouse_x = self.x
-        builtins.mouse_y = self.y
+        builtins.mouse_x = max(self.x, 0)
+        builtins.mouse_y = max(self.y, 0)
         builtins.mouse_button = self.button
         if self.action == 'PRESS':
             builtins.mouse_is_pressed = True


### PR DESCRIPTION
The issue with negative values of the mouse position was the result of the user moving the mouse past the left and top edges of the sketch during runtime.
The addition of a simple call to `max()` helped resolve the problem.