### PR TITLE
Removed pyglet.window.get_platform()

### DIFF
--- a/p5/sketch/base.py
+++ b/p5/sketch/base.py
@@ -41,16 +41,9 @@ last_recorded_time = time.time()
 builtins.pixel_width = 1
 builtins.pixel_height = 1
 
-platform = pyglet.window.get_platform()
-display = platform.get_default_display()
+display = pyglet.canvas.get_display()
 screen = display.get_default_screen()
-
-template = pyglet.gl.Config(samples_buffers=1, samples=2)
-try:
-    config = screen.get_best_config(template)
-except pyglet.window.NoSuchConfigException:
-    template = pyglet.gl.Config()
-    config = screen.get_best_config(template)
+config = screen.get_best_config()
 
 window = pyglet.window.Window(
     width=builtins.width,

--- a/p5/sketch/base.py
+++ b/p5/sketch/base.py
@@ -43,7 +43,8 @@ builtins.pixel_height = 1
 
 display = pyglet.canvas.get_display()
 screen = display.get_default_screen()
-config = screen.get_best_config()
+template = pyglet.gl.Config(double_buffer=1, sample_buffers=1)
+config = screen.get_best_config(template)
 
 window = pyglet.window.Window(
     width=builtins.width,


### PR DESCRIPTION
Fixes #10 .

* I contacted Pyglet community on bitbucket and they said that `platform`. API has been depreciated and will be removed soon : https://bitbucket.org/pyglet/pyglet/issues/175/pyglet-config-error-in-pygletwindowwindow

* Based on the Pyglet community response, I have updated the code accordingly and it works as expected on Mac.