### PR TITLE
raise ValueError when Magnitude of Vector is 0

### DIFF
--- a/p5/pmath/vector.py
+++ b/p5/pmath/vector.py
@@ -364,6 +364,8 @@ class Vector(Point):
 
     def normalize(self):
         """Set the magnitude of the vector to one."""
+        if self.magnitude == 0.0:
+            raise ValueError('Cannot normalize vector with magnitude 0')
         self.magnitude = 1
 
     def limit(self, upper_limit=None, lower_limit=None):

--- a/p5/pmath/vector.py
+++ b/p5/pmath/vector.py
@@ -365,7 +365,7 @@ class Vector(Point):
     def normalize(self):
         """Set the magnitude of the vector to one."""
         if self.magnitude == 0.0:
-            raise ValueError('Cannot normalize vector with magnitude 0')
+            raise ValueError('Cannot normalize vector having magnitude 0')
         self.magnitude = 1
 
     def limit(self, upper_limit=None, lower_limit=None):


### PR DESCRIPTION
Fixes #37.

Added test condition in line 376 to raise ValueError when magnitude of vector is 0.

```python 
>>> from p5 import *
>>> x = Vector(0, 0)
>>> print(x.magnitude)
0.0
>>> x.normalize()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/arihantparsoya/Documents/p5/p5/pmath/vector.py", line 368, in normalize
    raise ValueError('Cannot normalize vector with magnitude 0')
ValueError: Cannot normalize vector having magnitude 0
```