### PR TITLE
Fix typo on HSB mode with alpha

### DIFF
--- a/p5/core/color.py
+++ b/p5/core/color.py
@@ -124,7 +124,7 @@ def parse_color(*args, color_mode='RGB', **kwargs):
         rgb = (_r, _g, _b)
     elif (len(args) == 4) and color_mode.startswith('HSB'):
         _h, _s, _b, alpha = args
-        hsb = (_h, _s. _b)
+        hsb = (_h, _s, _b)
     elif 'gray' in kwargs:
         gray = kwargs['gray']
         rgb = gray, gray, gray


### PR DESCRIPTION
Stumbled across this issue recently using HSB color mode with an alpha value. Figured it was a rare enough of a situation that no one had caught the typo yet and it was an easy fix.