### PR TITLE
Fix typo in Processing user guide: event.key() to event.key

### DIFF
--- a/docs/guides/for-processing-users.rst
+++ b/docs/guides/for-processing-users.rst
@@ -250,10 +250,10 @@ Event System
          if event.key == 'A':
              # code to run when the <A> key is presesed.
 
-         elif event.key() == 'UP':
+         elif event.key == 'UP':
              # code to run when the <UP> key is presesed.
 
-         elif event.key() == 'SPACE':
+         elif event.key == 'SPACE':
              # code to run when the <SPACE> key is presesed.
 
          # ...etc


### PR DESCRIPTION
[Event System](https://p5.readthedocs.io/en/latest/guides/for-processing-users.html#event-system) example was calling event.key() instead of referencing the attribute event.key.