### PR TITLE
Fix #88: no_loop doesn't work in setup

### DIFF
--- a/p5/sketch/base.py
+++ b/p5/sketch/base.py
@@ -144,9 +144,7 @@ class Sketch(app.Canvas):
                     self.setup_done = True
                     self.show(visible=True)
                     self.redraw = True
-                    self.looping = False
                 else:
-                    self.looping = True
                     self.draw_method()
                     self.redraw = False
 


### PR DESCRIPTION
To fix issue #88 

Error is in the following snippet of base.py
```python
if self.looping or self.redraw:
                builtins.frame_count += 1
                if not self.setup_done:
                    self.setup_method()
                    self.setup_done = True
                    self.show(visible=True)
                    self.redraw = True
                    self.looping = False
                else:
                    self.looping = True
                    self.draw_method()
                    self.redraw = False
```

The error occurs because `self.looping` is controlled entirely by this block. Regardless of no_loop calls,
1) initially, `looping` is True (as no user code has been executed)
2) After the setup is called (no matter what happens to looping within the user setup), the block forces redraw to True and looping to False.
3) The next run through of the block sets looping to True initially. Note that if `no_loop()` was in `draw()`, it would be modified now, after setting it to true, and it would thus work. However, the call of `no_loop()` from setup is always over-written.

The direct solution to this is to remove the change `self.looping = True` from the second half of the block. This way, the change to looping in setup is not changed by the block. Note that this means the change `self.looping = False` in the first half of the block has to be removed too, as otherwise looping would forcibly be set to False.

Note that this is fine. The idea the developer probably had was that `looping` has to be false when `redraw` is true, but this is not necessary. It is important to note that in the first iteration, no matter the value of `looping`, `redraw` forces the first iteration of the second half of the block. Thus, this change is actually redundant (as we're setting it back to True right afterwards).

I have verified all the other references to the `looping` variable, and this is a safe modification, no other assumptions have been made about the variable.