### PR TITLE
Fix issue 60: background() doesn't work in setup.

### DIFF
--- a/p5/core/attribs.py
+++ b/p5/core/attribs.py
@@ -114,6 +114,16 @@ def background(*args, **kwargs):
 
     :note: When setting an image as the background, the dimensions of
         the image should be the same as that of the sketch window.
+    
+    :note:  Images can only be set as a background from draw().
+        This is because images do not actually change the renderer,
+        they only draw the image.
+        Colors, on the other hand, actually change the renderer color.
+    
+    :note:  Inconsistent behaviour between color and image.
+        Color changes the renderer background, whereas image simply draws.
+        This means background can be used with color in setup()
+        but images cannot be.
 
     :returns: The background color or image.
     :rtype: p5.Color | p5.PImage
@@ -138,12 +148,17 @@ def background(*args, **kwargs):
 
         return background_image
 
+    #Parse the color
+    background_color = Color(*args, **kwargs)
+    
+    #Draw a filled rectangle for immediate effect
     with push_style():
-        background_color = Color(*args, **kwargs)
         fill(background_color)
         no_stroke()
-
         with push_matrix():
             reset_transforms()
             rect((0, 0), builtins.width, builtins.height, mode='CORNER')
-            renderer.background_color = background_color.normalized
+
+    #Change the renderer settings for effect later
+    renderer.background_color = background_color.normalized
+    return background_color

--- a/p5/core/attribs.py
+++ b/p5/core/attribs.py
@@ -101,7 +101,7 @@ def no_tint():
     renderer.tint_enabled = False
 
 def background(*args, **kwargs):
-    """Set the background color for the renderer.
+    """Set the background color or image for the renderer.
 
     :param args: positional arguments to be parsed as a color.
     :type color_args: tuple
@@ -114,16 +114,6 @@ def background(*args, **kwargs):
 
     :note: When setting an image as the background, the dimensions of
         the image should be the same as that of the sketch window.
-    
-    :note:  Images can only be set as a background from draw().
-        This is because images do not actually change the renderer,
-        they only draw the image.
-        Colors, on the other hand, actually change the renderer color.
-    
-    :note:  Inconsistent behaviour between color and image.
-        Color changes the renderer background, whereas image simply draws.
-        This means background can be used with color in setup()
-        but images cannot be.
 
     :returns: The background color or image.
     :rtype: p5.Color | p5.PImage
@@ -146,6 +136,7 @@ def background(*args, **kwargs):
             with push_matrix():
                 image(background_image, (0, 0))
 
+        renderer.background_image = background_image
         return background_image
 
     #Parse the color
@@ -160,5 +151,6 @@ def background(*args, **kwargs):
             rect((0, 0), builtins.width, builtins.height, mode='CORNER')
 
     #Change the renderer settings for effect later
+    renderer.background_image = None
     renderer.background_color = background_color.normalized
     return background_color

--- a/p5/core/structure.py
+++ b/p5/core/structure.py
@@ -29,7 +29,8 @@ def push_style():
     by the following functions (the ones indicated by an asterisks '*'
     aren't available yet):
 
-    - background
+    - background_color
+    - background_image
     - fill, no_fill
     - stroke, no_stroke
     - rect_mode
@@ -53,6 +54,7 @@ def push_style():
 
     """
     prev_background_color = renderer.background_color
+    prev_background_image = renderer.background_image
     prev_fill_color = renderer.fill_color
     prev_fill_enabled = renderer.fill_enabled
     prev_stroke_enabled = renderer.stroke_enabled
@@ -70,6 +72,7 @@ def push_style():
     yield
 
     renderer.background_color = prev_background_color
+    renderer.background_image = prev_background_image
     renderer.fill_color = prev_fill_color
     renderer.fill_enabled = prev_fill_enabled
     renderer.stroke_color = prev_stroke_color

--- a/p5/sketch/base.py
+++ b/p5/sketch/base.py
@@ -144,7 +144,9 @@ class Sketch(app.Canvas):
                     self.setup_done = True
                     self.show(visible=True)
                     self.redraw = True
+                    self.looping = False
                 else:
+                    self.looping = True
                     self.draw_method()
                     self.redraw = False
 

--- a/p5/sketch/base.py
+++ b/p5/sketch/base.py
@@ -144,9 +144,7 @@ class Sketch(app.Canvas):
                     self.setup_done = True
                     self.show(visible=True)
                     self.redraw = True
-                    self.looping = False
                 else:
-                    self.looping = True
                     self.draw_method()
                     self.redraw = False
 

--- a/p5/sketch/renderer.py
+++ b/p5/sketch/renderer.py
@@ -36,6 +36,9 @@ from .shaders import src_default
 from .shaders import src_fbuffer
 from .shaders import src_texture
 
+from .structure import push_style
+from .transforms import push_matrix
+from .image import image, image_mode
 ##
 ## Renderer globals.
 ##
@@ -63,6 +66,7 @@ COLOR_DEFAULT_BG = (0.8, 0.8, 0.8, 1.0)
 ## Renderer Globals: STYLE/MATERIAL PROPERTIES
 ##
 background_color = COLOR_DEFAULT_BG
+background_image = None
 
 fill_color = COLOR_WHITE
 fill_enabled = True
@@ -149,7 +153,12 @@ def clear(color=True, depth=True):
     """Clear the renderer background."""
     gloo.set_state(clear_color=background_color)
     gloo.clear(color=color, depth=depth)
-
+    if background_image is not None:
+        with push_style():
+            tint_enabled = False
+            image_mode('corner')
+            with push_matrix():
+                image(background_image, (0, 0))
 def reset_view():
     """Reset the view of the renderer."""
     global viewport


### PR DESCRIPTION
Please check issue #60 for analysis on the issue.
Two changes made:
1) Function `background()` now returns the color if color is changed as expected
2) Function `background()` now permanently sets the renderer color to the new color. Note that this means that the behavior of the function is now inconsistent! Images can only be set in draw(), due to the mechanics of the renderer, while background color can be set from either draw() or setup().

I shall soon change the renderer to support images as backgrounds in setup() too.

Edit:
**Changed the renderer to be consistent with the color**
In the latest commit, both images and colors can be used in setup and draw.
This has been achieved by simply mimicking the background() function for images, minus checking validity, in the renderer's clear function.