### PR TITLE
fix Draw a line previous mouse position example

### DIFF
--- a/docs/tutorials/interactivity.rst
+++ b/docs/tutorials/interactivity.rst
@@ -166,7 +166,7 @@ Draw a line from the previous mouse position to the current position to show the
 
    def draw():
       background(204)
-      line(mouse_x, mouse_y, pmouse_x, pmouse_y)
+      line((mouse_x, mouse_y), (pmouse_x, pmouse_y))
 
    if __name__ == '__main__':
       run()


### PR DESCRIPTION
Hi!

the Draw a line from the previous mouse position example was broken.

I'm really like p5 so I planning to contribute for the documentation, fixing broken examples.

If you allow me of course

thanks for all your work!!