### PR TITLE
fix more tutorial examples

### DIFF
--- a/docs/tutorials/coordinate system and shapes.rst
+++ b/docs/tutorials/coordinate system and shapes.rst
@@ -105,11 +105,20 @@ Now let's look at what some code with shapes in more realistic setting, with win
 
 .. code:: python
 
-	size(200,200)
-	rectMode("CENTER")
-	rect((100,100),20,100)
-	ellipse((100,70),60,60)
-	ellipse((81,70),16,32) 
-	ellipse((119,70),16,32) 
-	line((90,150),(80,160))
-	line((110,150),(120,160))
+	from p5 import *
+
+
+	def setup():
+    	size(200, 200)
+
+
+	def draw():
+    	rect_mode(CENTER)
+		rect((100, 100), 20, 100)
+		ellipse((100, 70), 60, 60)
+		ellipse((81, 70), 16, 32)
+		ellipse((119, 70), 16, 32)
+		line((90, 150), (80, 160))
+		line((110, 150), (120, 160))
+	run()
+

--- a/docs/tutorials/interactivity.rst
+++ b/docs/tutorials/interactivity.rst
@@ -257,8 +257,8 @@ Use the logical operator ``and`` with an ``if`` structure to select a rectangula
 
    def draw():
       background(204)
-      if ((mouse_x > 40) and (mouse_x < 80) and
-         (mouse_y > 20) and (mouse_y < 80)):
+      if (mouse_x > 40) and (mouse_x < 80) and
+         (mouse_y > 20) and (mouse_y < 80):
          fill(255)
       else:
          fill(0)

--- a/docs/tutorials/interactivity.rst
+++ b/docs/tutorials/interactivity.rst
@@ -143,7 +143,7 @@ To invert the value of the mouse, subtract the mouse_x value from the width of t
    if __name__ == '__main__':
       run()
 
-The Processing variables ``pmouse_x`` and ``pmouse_y` store the mouse values from the previous frame. If the mouse does not move, the values will be the same, but if the mouse is moving quickly there can be large differences between the values. To see the difference, run the following program and alternate moving the mouse slowly and quickly. Watch the values print to the console.
+The Processing variables ``pmouse_x`` and ``pmouse_y`` store the mouse values from the previous frame. If the mouse does not move, the values will be the same, but if the mouse is moving quickly there can be large differences between the values. To see the difference, run the following program and alternate moving the mouse slowly and quickly. Watch the values print to the console.
 
 .. code:: python
 

--- a/docs/tutorials/interactivity.rst
+++ b/docs/tutorials/interactivity.rst
@@ -557,7 +557,7 @@ Because each character has a numeric value as defined by the ASCII table (p. 605
 
       global angle
       if key_is_pressed:
-         if (key >= 32) and (key <= 126):
+         if (ord(str(key)) >= 32) and (ord(str(key)) <= 126):
             #  If the key is alphanumeric, use its value as an angle
             angle = (ord(str(key)) - 32) * 3
 

--- a/docs/tutorials/interactivity.rst
+++ b/docs/tutorials/interactivity.rst
@@ -28,9 +28,12 @@ The Processing variables ``mouse_x`` and ``mouse_y`` store the x-coordinate and 
 
 .. code:: python
 
-	def draw():
-		frame_rate(12)
-		print(mouse_x, " : ", mouse_y)
+   def draw():
+      # Your draw goes here 
+      print(mouse_x, " : ", mouse_y) # Use this at the end of the draw to
+                                     # print in console the mouse x and y
+        
+   run(frame_rate=12) # Use this to control the frame rate  
 
 When a program starts, the ``mouse_x`` and ``mouse_y`` values are 0. If the cursor moves into the display window, the values are set to the current position of the cursor. If the cursor is at the left, the ``mouse_x`` value is 0 and the value increases as the cursor moves to the right. If the cursor is at the top, the ``mouse_y`` value is 0 and the value increases as the cursor moves down. If ``mouse_x`` and ``mouse_y`` are used in programs without a ``draw()`` or if ``no_loop()`` is run in ``setup()``, the values will always be 0.
 

--- a/docs/tutorials/interactivity.rst
+++ b/docs/tutorials/interactivity.rst
@@ -717,7 +717,7 @@ The code inside the ``mouse_moved()`` and ``mouse_dragged()`` event functions ar
 
    from p5 import *
 
-   dragX, dragY, moveX, moveY = (0, 0, 0, 0)
+   dragX = dragY = moveX = moveY = 0
 
    def setup():
       size(100, 100)
@@ -732,10 +732,12 @@ The code inside the ``mouse_moved()`` and ``mouse_dragged()`` event functions ar
       ellipse((moveX, moveY), 33, 33) # Gray circle
 
    def mouse_moved():
+      global moveX, moveY
       moveX = mouse_x
       moveY = mouse_y
 
    def mouse_dragged():
+      global dragX, dragY
       dragX = mouse_x
       dragY = mouse_y
 

--- a/docs/tutorials/interactivity.rst
+++ b/docs/tutorials/interactivity.rst
@@ -584,7 +584,7 @@ In addition to reading key values for numbers, letters, and symbols, Processing 
 
    from p5 import *
 
-   y = 35
+   y = 0
 
    def setup():
        size(100, 100)

--- a/docs/tutorials/interactivity.rst
+++ b/docs/tutorials/interactivity.rst
@@ -148,8 +148,11 @@ The Processing variables ``pmouse_x`` and ``pmouse_y`` store the mouse values fr
 .. code:: python
 
    def draw():
-      frame_rate(12)
-      print(pmouse_y - mouse_x)
+      # Your draw goes here 
+      print(mouse_x, " : ", mouse_y) # Use this at the end of the draw to
+                                     # print in console the mouse x and y
+        
+   run(frame_rate=12) # Use this to control the frame rate
 
 Draw a line from the previous mouse position to the current position to show the changing position in one frame and reveal the speed and direction of the mouse. When the mouse is not moving, a point is drawn, but quick mouse movements create long lines.
 


### PR DESCRIPTION
fixed the "coordinate system and shapes" example at the end of the tutorial so now works as intended 
fixed the "Mouse Data" print x and y mouse position
fixed some text format problems in "Interactivity" tutorial
fixed the angle example of interactivity tutorial, added ord and str methods
in Coded keys example is not necessary define "y" value as 35 outside def 
fixed the "mouse_moved()" and "mouse_dragged()" example in the Interactivity Tutorial 