### PR TITLE
[DOC] Remove extra pop_matrix() call in arm example

### DIFF
--- a/docs/examples/transform/arm.rst
+++ b/docs/examples/transform/arm.rst
@@ -78,7 +78,6 @@ The angle of each segment is controlled with the mouseX and mouseY position. The
 		with push_matrix():
 			segment(x, y, angle1)
 			segment(segLength, 0, angle2)
-			pop_matrix()
 
 	def segment(x, y, a):
 		translate(x, y)


### PR DESCRIPTION
According to the documentation [here](https://p5.readthedocs.io/en/latest/guides/for-processing-users.html), `push_matrix` is a context manager and `pop_matrix` does not exist. In reality, `pop_matrix` exists but seems to do nothing according to the [source](https://github.com/p5py/p5/blob/1b233fdd59f19e97341e5cfb75bccb821ff79eab/p5/core/transforms.py#L41).

While a future PR is probably needed to clean up the implementation of the API, this PR removes the extraneous pop_matrix() call in the arm example code.