### PR TITLE
Initialize self.children in Geometry base class

### DIFF
--- a/p5/core/geometry.py
+++ b/p5/core/geometry.py
@@ -55,6 +55,8 @@ class Geometry:
 		self.stroke_indices = []
 
 		self.matrix = np.identity(4)
+		
+		self.children = []
 
 	def reset(self):
 		"""


### PR DESCRIPTION
[`draw_shape`](https://github.com/p5py/p5/blob/1b233fdd59f19e97341e5cfb75bccb821ff79eab/p5/core/primitives.py#L571) expects a shape to have a `children` attribute. Adding this initialization resolves #141.