### PR TITLE
Closes #158 draw() being called multiple times and frame_count was incremented in wrong manner

### DIFF
--- a/p5/sketch/base.py
+++ b/p5/sketch/base.py
@@ -91,8 +91,8 @@ class Sketch(app.Canvas):
         builtins.frame_rate = round(self.fps, 2)
 
         with p5.renderer.draw_loop():
-            builtins.frame_count += 1
             if not self.setup_done:
+                builtins.frame_count += 1
                 self.setup_method()
                 self.setup_done = True
                 self.show(visible=True)
@@ -101,7 +101,10 @@ class Sketch(app.Canvas):
                 if self.looping is None:
                     self.looping = True
             elif self.looping:
+                builtins.frame_count += 1
                 self.draw_method()
+            elif not self.looping:
+                pass
             elif self.redraw:
                 self.draw_method()
                 self.redraw = False


### PR DESCRIPTION
In the base.py frame_count was incremented without checking whether or not looping is set to true or false
Draw() was called again because there was no check to see if looping is false and redraw is true, then don't call draw()
Fixed it by putting a elif not self.looping : pass in the if else statements, 

You can test to see if everything and frame_count are working fine by putting print(frame_count) in base.py at various positions in the code