### PR TITLE
Correct implementation of no_loop()

### DIFF
--- a/p5/sketch/base.py
+++ b/p5/sketch/base.py
@@ -100,14 +100,17 @@ class Sketch(app.Canvas):
                     self.redraw = False
                 if self.looping is None:
                     self.looping = True
+
+            elif self.redraw:
+                builtins.frame_count += 1
+                self.draw_method()
+                self.redraw = False
             elif self.looping:
                 builtins.frame_count += 1
                 self.draw_method()
+                self.redraw = False
             elif not self.looping:
                 pass
-            elif self.redraw:
-                self.draw_method()
-                self.redraw = False
 
             while len(self.handler_queue) != 0:
                 function, event = self.handler_queue.pop(0)


### PR DESCRIPTION
Closes #175 

#158 had problem of draw() being called two times if we use no_loop() inside draw() function, which was fixed by a PR by me but it led to #175, that is no_loop() when used in setup() don't call draw() once, as per Processing original documentation

This PR calls draw() once when used in setup() and don't call draw() again if no_loop() is used in draw() again, also I have tested the frame_count for each call and frame_count is being incremented as described by @jeremydouglass  in #162 comments,  

The issue #158 and #162 is taken care by this PR , I have tested the code for loop(), no_loop(), redraw() for both in setup() and draw() functions and some other codes from examples of p5 

But you can test it for some other scenarios too :)

PS : size() when used in setup() along with no_loop() is still buggy, but I don't think it is happening due to no_loop()