### PR TITLE
Fixed typo in PShape tutorial

### DIFF
--- a/docs/tutorials/pshape.rst
+++ b/docs/tutorials/pshape.rst
@@ -220,7 +220,7 @@ As we mentioned earlier, one reason to use PShape is just to help you organize y
 	        vertex(-23, 7)
 	        vertex(-47, -15)
 	        vertex(-14, -20)
-	        endShape("CLOSE")
+	        end_shape("CLOSE")
 
 and in `draw()`, you are iterating through an array of Star objects, displaying each one.
 


### PR DESCRIPTION
[typo in Pshape tutorial](https://p5.readthedocs.io/en/latest/tutorials/pshape.html#many-pshapes)
typo was: endShape("CLOSE").

Changed to correct syntax: end_shape("CLOSE")