### PR TITLE
Move 2D rendering from PShape to renderer2d

### DIFF
--- a/p5/core/primitives.py
+++ b/p5/core/primitives.py
@@ -31,7 +31,7 @@ from .constants import SType
 
 from . import p5
 
-__all__ = ['point', 'line', 'arc', 'triangle', 'quad',
+__all__ = ['Arc', 'point', 'line', 'arc', 'triangle', 'quad',
            'rect', 'square', 'circle', 'ellipse', 'ellipse_mode',
            'rect_mode', 'bezier', 'curve', 'create_shape', 'draw_shape']
 

--- a/p5/core/primitives.py
+++ b/p5/core/primitives.py
@@ -82,7 +82,7 @@ class Arc(PShape):
         self._radii = radii
         self._start_angle = start_angle
         self._stop_angle = stop_angle
-        self._mode = mode
+        self.arc_mode = mode
 
         gl_type = SType.TESS if mode in ['OPEN', 'CHORD'] else SType.TRIANGLE_FAN
         super().__init__(fill_color=fill_color,
@@ -114,7 +114,7 @@ class Arc(PShape):
         start_index = int((self._start_angle / (math.pi * 2)) * sclen)
         end_index = int((self._stop_angle / (math.pi * 2)) * sclen)
 
-        vertices = [(c1x, c1y, 0)] if self._mode in ['PIE', None] else []
+        vertices = [(c1x, c1y, 0)] if self.arc_mode in ['PIE', None] else []
         for idx in range(start_index, end_index, inc):
             i = idx % sclen
             vertices.append((
@@ -127,7 +127,7 @@ class Arc(PShape):
             c1y + ry * SINCOS[end_index % sclen][0],
             0
         ))
-        if self._mode == 'CHORD' or self._mode == 'PIE':
+        if self.arc_mode == 'CHORD' or self.arc_mode == 'PIE':
             vertices.append(vertices[0])
         self.vertices = vertices
 

--- a/p5/core/primitives.py
+++ b/p5/core/primitives.py
@@ -90,18 +90,6 @@ class Arc(PShape):
                          stroke_join=stroke_join, stroke_cap=stroke_cap, shape_type=gl_type, **kwargs)
         self._tessellate()
 
-    def update_draw_queue(self):
-        stroke_state = p5.renderer.stroke_enabled
-        if self._mode in [None, 'PIE']:
-            p5.renderer.stroke_enabled = False
-        PShape.update_draw_queue(self)
-        if stroke_state:  # If stroke was enabled
-            if self._mode is None:
-                self.overriden_draw_queue.append(self._get_line_from_verts(self.vertices[1:]))
-            if self._mode == 'PIE':
-                self.overriden_draw_queue.append(self._get_line_from_verts(self.vertices))
-        p5.renderer.stroke_enabled = stroke_state
-
     def _tessellate(self):
         """Generate vertex and face data using radii.
         """
@@ -142,7 +130,6 @@ class Arc(PShape):
         if self._mode == 'CHORD' or self._mode == 'PIE':
             vertices.append(vertices[0])
         self.vertices = vertices
-        self.update_draw_queue()
 
 @_draw_on_return
 def point(x, y, z=0):

--- a/p5/core/tess.py
+++ b/p5/core/tess.py
@@ -6,7 +6,7 @@ import numpy as np
 class Tessellator:
     def __init__(self):
         self.tess = gluNewTess()
-        self.draw_queue = []  # [[gl_type, vertices, idx]...]
+        self.primitives = []  # [[gl_type, vertices, idx]...]
         self.vertices = []    # Vertices for the current shape
         self.type = None      # Type for the current shape
 
@@ -15,19 +15,9 @@ class Tessellator:
                        GL_TRIANGLES: 'triangles',
                        GL_LINE_LOOP: 'line_loop'}
 
-        def to_tess_string(x):
-            if x == GL_TRIANGLE_FAN:
-                return "GL_TRIANGLE_FAN"
-            elif x == GL_LINE_LOOP:
-                return "GL_LINE_LOOP"
-            elif x == GL_TRIANGLE_STRIP:
-                return "GL_TRIANGLE_STRIP"
-            elif x == GL_TRIANGLES:
-                return "GL_TRIANGLES"
-
         def end_shape_handler():
             curr_obj = [gl_mode_map[self.type], self.vertices, np.arange(len(self.vertices), dtype=np.uint32)]
-            self.draw_queue.append(curr_obj)
+            self.primitives.append(curr_obj)
 
         def begin_shape_handler(x):
             self.type = x
@@ -46,10 +36,10 @@ class Tessellator:
         gluTessCallback(self.tess, GLU_TESS_BEGIN, begin_shape_handler)
         gluTessCallback(self.tess, GLU_TESS_COMBINE, combine_handler)
 
-    def process_draw_queue(self):
+    def get_result(self):
         """Returns the current primitive_list and clears it
         For the format of the draw queue, see the definition of self.primitive_list in `__init__`
         """
-        res = self.draw_queue
-        self.draw_queue = []
+        res = self.primitives
+        self.primitives = []
         return res

--- a/p5/core/tess.py
+++ b/p5/core/tess.py
@@ -47,8 +47,8 @@ class Tessellator:
         gluTessCallback(self.tess, GLU_TESS_COMBINE, combine_handler)
 
     def process_draw_queue(self):
-        """Returns the current draw_queue and clears it
-        For the format of the draw queue, see the definition of self.draw_queue in `__init__`
+        """Returns the current primitive_list and clears it
+        For the format of the draw queue, see the definition of self.primitive_list in `__init__`
         """
         res = self.draw_queue
         self.draw_queue = []

--- a/p5/sketch/renderer2d.py
+++ b/p5/sketch/renderer2d.py
@@ -19,6 +19,9 @@
 import numpy as np
 import math
 from ..pmath import matrix
+from ..core import p5
+from ..core.constants import SType
+from ..core.primitives import Arc
 
 import builtins
 
@@ -35,6 +38,146 @@ from .shaders2d import src_default
 from .shaders2d import src_fbuffer
 from .shaders2d import src_texture
 from .shaders2d import src_line
+
+from OpenGL.GLU import gluTessBeginPolygon, gluTessBeginContour, gluTessEndPolygon, gluTessEndContour, gluTessVertex
+
+
+def _tess_new_contour(vertices):
+	"""Given a list of vertices, evoke gluTess to create a contour
+	"""
+	gluTessBeginContour(p5.tess.tess)
+	for v in vertices:
+		gluTessVertex(p5.tess.tess, v, v)
+	gluTessEndContour(p5.tess.tess)
+
+
+def _add_vertices_to_draw_queue(draw_queue, gl_name, vertices):
+	"""Adds an object of type gl_name with vertices in sequential order to the draw queue
+	"""
+	draw_queue.append([gl_name, np.asarray(vertices),
+									  np.arange(len(vertices), dtype=np.uint32)])
+
+
+def _get_line_from_verts(vertices):
+	"""Given a list of vertices, chain them sequentially in a line object that's ready for draw queue
+	"""
+	return ['lines', np.asarray(vertices), [np.arange(len(vertices))]]
+
+
+def _get_line_from_indices(vertices, start, end):
+	"""Given two columns of indices that represent edges, return a line object that's ready for draw queue
+
+	:param vertices: List of vertices
+	:type vertices: list
+
+	:param start: Array of start positions of edges in vertex indices
+	:type start: np.ndarray
+
+	:param end: Array of end positions fo edges in vertex indices
+	:type end: np.ndarray
+	"""
+	return ['lines', np.asarray(vertices),
+			np.hstack((np.vstack(start), np.vstack(end)))]
+
+
+def _add_edges_to_draw_queue(draw_queue, vertices, start, end):
+	"""Adds edges to draw_queue, given their start and end positions (in vertex indices)
+
+	:param start: Array of start positions of edges in vertex indices
+	:type start: np.ndarray
+
+	:param end: Array of end positions fo edges in vertex indices
+	:type end: np.ndarray
+	"""
+	draw_queue.append(_get_line_from_indices(vertices, start, end))
+
+
+def get_borders(shape):
+	draw_q = []
+	n_vert = len(shape.vertices)
+	if shape.shape_type == SType.TRIANGLES:
+		assert n_vert % 3 == 0, "TRIANGLES requires the number of vertices to be a multiple of 3"
+		start = np.arange(n_vert)
+		end = np.arange(n_vert) + np.tile([1, 1, -2], n_vert // 3)
+		_add_edges_to_draw_queue(draw_q, shape.vertices, start, end)
+	elif shape.shape_type == SType.TRIANGLE_STRIP:
+		start = np.concatenate((np.arange(n_vert - 1), np.arange(n_vert - 2)))
+		end = np.concatenate((np.arange(1, n_vert), np.arange(2, n_vert)))
+		_add_edges_to_draw_queue(draw_q, shape.vertices, start, end)
+	elif shape.shape_type == SType.TRIANGLE_FAN:
+		start = np.concatenate((np.repeat([0], n_vert - 1), np.arange(1, n_vert - 1)))
+		end = np.concatenate((np.arange(1, n_vert), np.arange(2, n_vert)))
+		_add_edges_to_draw_queue(draw_q, shape.vertices, start, end)
+	elif shape.shape_type == SType.QUADS:
+		start = np.arange(n_vert)
+		end = np.arange(n_vert) + np.tile([1, 1, 1, -3], n_vert // 4)
+		_add_edges_to_draw_queue(draw_q, shape.vertices, start, end)
+	elif shape.shape_type == SType.QUAD_STRIP:
+		start = np.concatenate((np.arange(0, n_vert, 2), np.arange(n_vert - 2)))
+		end = np.concatenate((np.arange(1, n_vert, 2), np.arange(2, n_vert)))
+		_add_edges_to_draw_queue(draw_q, shape.vertices, start, end)
+	elif shape.shape_type == SType.LINES:
+		start = np.arange(0, n_vert, 2)
+		end = np.arange(1, n_vert, 2)
+		_add_edges_to_draw_queue(draw_q, shape.vertices, start, end)
+	elif shape.shape_type == SType.LINE_STRIP:
+		draw_q.append(_get_line_from_verts(shape.vertices))
+	elif shape.shape_type == SType.TESS:
+		draw_q.append(_get_line_from_verts(shape.vertices))
+		for contour in shape.contours:
+			draw_q.append(_get_line_from_verts(contour))
+	return draw_q
+
+
+def get_meshes(shape):
+	draw_q = []
+	n_vert = len(shape.vertices)
+	if shape.shape_type in [SType.TRIANGLES, SType.TRIANGLE_STRIP, SType.TRIANGLE_FAN, SType.QUAD_STRIP]:
+		gl_name = shape.shape_type.name.lower()
+		if gl_name == 'quad_strip':  # vispy does not support quad_strip
+			gl_name = 'triangle_strip'  # but it can be drawn using triangle_strip
+		_add_vertices_to_draw_queue(draw_q, gl_name, shape.vertices)
+	elif shape.shape_type == SType.QUADS:
+		n_quad = len(shape.vertices) // 4
+		draw_q.append(['triangles', np.asarray(shape.vertices),
+					   np.repeat(np.arange(0, n_vert, 4, dtype=np.uint32), 6) +
+					   np.tile(np.array([0, 1, 2, 0, 2, 3], dtype=np.uint32), n_quad)])
+	elif shape.shape_type == SType.TESS:
+		gluTessBeginPolygon(p5.tess.tess, None)
+		_tess_new_contour(shape.vertices)
+		if len(shape.contours) > 0:
+			for contour in shape.contours:
+				_tess_new_contour(contour)
+		gluTessEndPolygon(p5.tess.tess)
+		draw_q += p5.tess.process_draw_queue()
+	return draw_q
+
+
+def update_draw_queue(shape):
+	draw_q = []
+	if isinstance(shape, Arc):
+		# Render meshes
+		if p5.renderer.fill_enabled:
+			draw_q.extend(get_meshes(shape))
+		# Render borders
+		if p5.renderer.stroke_enabled:
+			if shape._mode in ['CHORD', 'OPEN']:  # Implies shape.shape_type == TESS
+				draw_q.extend(get_borders(shape))
+			elif shape._mode is None:             # Implies shape.shape_type == TRIANGLE_FAN
+				draw_q.append(_get_line_from_verts(shape.vertices[1:]))
+			elif shape._mode == 'PIE':            # Implies shape.shape_type == TRIANGLE_FAN
+				draw_q.append(_get_line_from_verts(shape.vertices))
+	else:
+		# Render points
+		if shape.shape_type == SType.POINTS:
+			_add_vertices_to_draw_queue(draw_q, 'points', shape.vertices)
+		# Render meshes
+		if p5.renderer.fill_enabled:
+			draw_q.extend(get_meshes(shape))
+		# Render borders
+		if p5.renderer.stroke_enabled:
+			draw_q.extend(get_borders(shape))
+	return draw_q
 
 class Renderer2D:
 	def __init__(self):
@@ -228,19 +371,16 @@ class Renderer2D:
 		stroke_cap = shape.stroke_cap
 		stroke_join = shape.stroke_join
 
-		# If shape comes with prepackaged objects, use these instead
-		if shape.overriden_draw_queue:
-			for obj in shape.overriden_draw_queue:
-				stype, vertices, idx = obj
-				# Transform vertices
-				vertices = self._transform_vertices(
-					np.hstack([vertices, np.ones((len(vertices), 1))]),
-					shape._matrix,
-					self.transform_matrix)
-				# Add to draw queue
-				self._add_to_draw_queue_simple(stype, vertices, idx, fill, stroke, stroke_weight, stroke_cap, stroke_join)
-		else:
-			assert False, "Overridden draw queue unimplemented"
+		obj_list = update_draw_queue(shape)
+		for obj in obj_list:
+			stype, vertices, idx = obj
+			# Transform vertices
+			vertices = self._transform_vertices(
+				np.hstack([vertices, np.ones((len(vertices), 1))]),
+				shape._matrix,
+				self.transform_matrix)
+			# Add to draw queue
+			self._add_to_draw_queue_simple(stype, vertices, idx, fill, stroke, stroke_weight, stroke_cap, stroke_join)
 
 	def flush_geometry(self):
 		"""Flush all the shape geometry from the draw queue to the GPU.

--- a/p5/sketch/renderer2d.py
+++ b/p5/sketch/renderer2d.py
@@ -213,8 +213,9 @@ class Renderer2D:
 	def _transform_vertices(self, vertices, local_matrix, global_matrix):
 		return np.dot(np.dot(vertices, local_matrix.T), global_matrix.T)[:, :3]
 
-	# Adds shape of stype to draw queue
-	def _add_to_draw_queue_simple(self, stype, vertices, idx, fill, stroke=None, stroke_weight=None, stroke_cap=None, stroke_join=None):
+	def _add_to_draw_queue_simple(self, stype, vertices, idx, fill, stroke, stroke_weight, stroke_cap, stroke_join):
+		"""Adds shape of stype to draw queue
+		"""
 		if stype == 'lines':
 			self.draw_queue.append((stype, (vertices, idx, stroke, stroke_weight, stroke_cap, stroke_join)))
 		else:
@@ -240,54 +241,6 @@ class Renderer2D:
 				self._add_to_draw_queue_simple(stype, vertices, idx, fill, stroke, stroke_weight, stroke_cap, stroke_join)
 		else:
 			assert False, "Overridden draw queue unimplemented"
-
-	def add_to_draw_queue(self, stype, vertices, edges, faces, fill=None, stroke=None,
-			stroke_weight=None, stroke_cap=None, stroke_join=None):
-		"""Add the given vertex data to the draw queue.
-
-		:param stype: type of shape to be added. Should be one of {'poly',
-			'path', 'point'}
-		:type stype: str
-
-		:param vertices: (N, 3) array containing the vertices to be drawn.
-		:type vertices: np.ndarray
-
-		:param edges: (N, 2) array containing edges as tuples of indices
-			into the vertex array. This can be None when not appropriate
-			(eg. for points)
-		:type edges: None | np.ndarray
-
-		:param faces: (N, 3) array containing faces as tuples of indices
-			into the vertex array. For 'point' and 'path' shapes, this can
-			be None
-		:type faces: np.ndarray
-
-		:param fill: Fill color of the shape as a normalized RGBA tuple.
-			When set to `None` the shape doesn't get a fill (default: None)
-		:type fill: None | tuple
-
-		:param stroke: Stroke color of the shape as a normalized RGBA
-			tuple. When set to `None` the shape doesn't get stroke
-			(default: None)
-		:type stroke: None | tuple
-
-		"""
-
-		fill_shape = self.fill_enabled and not (fill is None)
-		stroke_shape = self.stroke_enabled and not (stroke is None)
-
-		if fill_shape and stype not in ['point', 'path']:
-			idx = np.array(faces, dtype=np.uint32).ravel()
-			self.draw_queue.append(["triangles", (vertices, idx, fill)])
-
-		if stroke_shape:
-			if stype == 'point':
-				idx = np.arange(0, len(vertices), dtype=np.uint32)
-				self.draw_queue.append(["points", (vertices, idx, stroke)])
-			else:
-				self.draw_queue.append(["lines", (
-					vertices, edges, stroke, stroke_weight, stroke_cap, stroke_join
-					)])
 
 	def flush_geometry(self):
 		"""Flush all the shape geometry from the draw queue to the GPU.


### PR DESCRIPTION
This PR decouples most of the OpenGL specific rendering logic from PShape, making it easier to write different backends.