### PR TITLE
Abstract common rendering logic in OpenGLRenderer

### DIFF
--- a/p5/sketch/openglrenderer.py
+++ b/p5/sketch/openglrenderer.py
@@ -1,8 +1,54 @@
 from abc import ABC
 import numpy as np
 
+
 # Abstract class that contains common code for OpenGL renderers
 class OpenGLRenderer(ABC):
+    def __init__(self):
+        self.default_prog = None
+        self.fbuffer_prog = None
+
+        self.fbuffer = None
+        self.fbuffer_tex_front = None
+        self.fbuffer_tex_back = None
+
+        self.vertex_buffer = None
+        self.index_buffer = None
+
+        # Renderer Globals: USEFUL CONSTANTS
+        self.COLOR_WHITE = (1, 1, 1, 1)
+        self.COLOR_BLACK = (0, 0, 0, 1)
+        self.COLOR_DEFAULT_BG = (0.8, 0.8, 0.8, 1.0)
+
+        # Renderer Globals: STYLE/MATERIAL PROPERTIES
+        #
+        self.background_color = self.COLOR_DEFAULT_BG
+
+        self.fill_color = self.COLOR_WHITE
+        self.fill_enabled = True
+
+        self.stroke_color = self.COLOR_BLACK
+        self.stroke_enabled = True
+
+        self.tint_color = self.COLOR_BLACK
+        self.tint_enabled = False
+
+        # Renderer Globals: Curves
+        self.stroke_weight = 1
+        self.stroke_cap = 2
+        self.stroke_join = 0
+
+        # Renderer Globals
+        # VIEW MATRICES, ETC
+        #
+        self.viewport = None
+        self.texture_viewport = None
+        self.transform_matrix = np.identity(4)
+        self.projection_matrix = np.identity(4)
+
+        # Renderer Globals: RENDERING
+        self.draw_queue = []
+
     def render_default(self, draw_type, draw_queue):
         # 1. Get the maximum number of vertices persent in the shapes
         # in the draw queue.

--- a/p5/sketch/openglrenderer.py
+++ b/p5/sketch/openglrenderer.py
@@ -1,6 +1,9 @@
 from abc import ABC
 import numpy as np
 
+from vispy.gloo import Program, VertexBuffer, FrameBuffer, IndexBuffer
+from .shaders2d import src_default, src_fbuffer
+
 
 # Abstract class that contains common code for OpenGL renderers
 class OpenGLRenderer(ABC):
@@ -48,6 +51,32 @@ class OpenGLRenderer(ABC):
 
         # Renderer Globals: RENDERING
         self.draw_queue = []
+
+    def initialize_renderer(self):
+        self.fbuffer = FrameBuffer()
+
+        vertices = np.array([[-1.0, -1.0],
+                             [+1.0, -1.0],
+                             [-1.0, +1.0],
+                             [+1.0, +1.0]],
+                            np.float32)
+        texcoords = np.array([[0.0, 0.0],
+                              [1.0, 0.0],
+                              [0.0, 1.0],
+                              [1.0, 1.0]],
+                             dtype=np.float32)
+
+        self.fbuf_vertices = VertexBuffer(data=vertices)
+        self.fbuf_texcoords = VertexBuffer(data=texcoords)
+
+        self.fbuffer_prog = Program(src_fbuffer.vert, src_fbuffer.frag)
+        self.fbuffer_prog['texcoord'] = self.fbuf_texcoords
+        self.fbuffer_prog['position'] = self.fbuf_vertices
+
+        self.vertex_buffer = VertexBuffer()
+        self.index_buffer = IndexBuffer()
+
+        self.default_prog = Program(src_default.vert, src_default.frag)
 
     def render_default(self, draw_type, draw_queue):
         # 1. Get the maximum number of vertices persent in the shapes

--- a/p5/sketch/openglrenderer.py
+++ b/p5/sketch/openglrenderer.py
@@ -48,3 +48,14 @@ class OpenGLRenderer(ABC):
         # the buffers.
         #
         self.default_prog.draw(draw_type, indices=self.index_buffer)
+
+    def cleanup(self):
+        """Run the clean-up routine for the renderer.
+
+        This method is called when all drawing has been completed and the
+        program is about to exit.
+
+        """
+        self.default_prog.delete()
+        self.fbuffer_prog.delete()
+        self.fbuffer.delete()

--- a/p5/sketch/openglrenderer.py
+++ b/p5/sketch/openglrenderer.py
@@ -1,0 +1,50 @@
+from abc import ABC
+import numpy as np
+
+# Abstract class that contains common code for OpenGL renderers
+class OpenGLRenderer(ABC):
+    def render_default(self, draw_type, draw_queue):
+        # 1. Get the maximum number of vertices persent in the shapes
+        # in the draw queue.
+        #
+        if len(draw_queue) == 0:
+            return
+
+        num_vertices = 0
+        for vertices, _, _ in draw_queue:
+            num_vertices = num_vertices + len(vertices)
+
+        # 2. Create empty buffers based on the number of vertices.
+        #
+        data = np.zeros(num_vertices,
+                        dtype=[('position', np.float32, 3),
+                               ('color', np.float32, 4)])
+
+        # 3. Loop through all the shapes in the geometry queue adding
+        # it's information to the buffer.
+        #
+        sidx = 0
+        draw_indices = []
+        for vertices, idx, color in draw_queue:
+            num_shape_verts = len(vertices)
+
+            data['position'][sidx:(sidx + num_shape_verts), ] = np.array(vertices)
+
+            color_array = np.array([color] * num_shape_verts)
+            data['color'][sidx:sidx + num_shape_verts, :] = color_array
+
+            draw_indices.append(sidx + idx)
+
+            sidx += num_shape_verts
+
+        self.vertex_buffer.set_data(data)
+        self.index_buffer.set_data(np.hstack(draw_indices))
+
+        # 4. Bind the buffer to the shader.
+        #
+        self.default_prog.bind(self.vertex_buffer)
+
+        # 5. Draw the shape using the proper shape type and get rid of
+        # the buffers.
+        #
+        self.default_prog.draw(draw_type, indices=self.index_buffer)

--- a/p5/sketch/openglrenderer.py
+++ b/p5/sketch/openglrenderer.py
@@ -59,3 +59,6 @@ class OpenGLRenderer(ABC):
         self.default_prog.delete()
         self.fbuffer_prog.delete()
         self.fbuffer.delete()
+
+    def _transform_vertices(self, vertices, local_matrix, global_matrix):
+        return np.dot(np.dot(vertices, local_matrix.T), global_matrix.T)[:, :3]

--- a/p5/sketch/renderer2d.py
+++ b/p5/sketch/renderer2d.py
@@ -26,16 +26,11 @@ from ..core.primitives import Arc
 import builtins
 
 from vispy import gloo
-from vispy.gloo import FrameBuffer
-from vispy.gloo import IndexBuffer
 from vispy.gloo import Program
 from vispy.gloo import Texture2D
 from vispy.gloo import VertexBuffer
 
 from contextlib import contextmanager
-
-from .shaders2d import src_default
-from .shaders2d import src_fbuffer
 from .shaders2d import src_texture
 from .shaders2d import src_line
 from .openglrenderer import OpenGLRenderer
@@ -225,33 +220,9 @@ class Renderer2D(OpenGLRenderer):
 		self.modelview_matrix = np.identity(4)
 
 	def initialize_renderer(self):
-		self.fbuffer = FrameBuffer()
-
-		vertices = np.array([[-1.0, -1.0],
-							 [+1.0, -1.0],
-							 [-1.0, +1.0],
-							 [+1.0, +1.0]],
-							np.float32)
-		texcoords = np.array([[0.0, 0.0],
-							  [1.0, 0.0],
-							  [0.0, 1.0],
-							  [1.0, 1.0]],
-							 dtype=np.float32)
-
-		self.fbuf_vertices = VertexBuffer(data=vertices)
-		self.fbuf_texcoords = VertexBuffer(data=texcoords)
-
-		self.fbuffer_prog = Program(src_fbuffer.vert, src_fbuffer.frag)
-		self.fbuffer_prog['texcoord'] = self.fbuf_texcoords
-		self.fbuffer_prog['position'] = self.fbuf_vertices
-
-		self.vertex_buffer = VertexBuffer()
-		self.index_buffer = IndexBuffer()
-
-		self.default_prog = Program(src_default.vert, src_default.frag)
+		super().initialize_renderer()
 		self.texture_prog = Program(src_texture.vert, src_texture.frag)
 		self.texture_prog['texcoord'] = self.fbuf_texcoords
-
 		self.reset_view()
 
 	def reset_view(self):

--- a/p5/sketch/renderer2d.py
+++ b/p5/sketch/renderer2d.py
@@ -219,52 +219,10 @@ def get_render_primitives(shape):
 
 class Renderer2D(OpenGLRenderer):
 	def __init__(self):
-		self.default_prog = None
-		self.fbuffer_prog = None
+		super().__init__()
 		self.texture_prog = None
 		self.line_prog = None
-
-		self.fbuffer = None
-		self.fbuffer_tex_front = None
-		self.fbuffer_tex_back = None
-
-		self.vertex_buffer = None
-		self.index_buffer = None
-
-		## Renderer Globals: USEFUL CONSTANTS
-		self.COLOR_WHITE = (1, 1, 1, 1)
-		self.COLOR_BLACK = (0, 0, 0, 1)
-		self.COLOR_DEFAULT_BG = (0.8, 0.8, 0.8, 1.0)
-
-		## Renderer Globals: STYLE/MATERIAL PROPERTIES
-		##
-		self.background_color = self.COLOR_DEFAULT_BG
-
-		self.fill_color = self.COLOR_WHITE
-		self.fill_enabled = True
-
-		self.stroke_color = self.COLOR_BLACK
-		self.stroke_enabled = True
-
-		self.tint_color = self.COLOR_BLACK
-		self.tint_enabled = False
-
-		## Renderer Globals: Curves
-		self.stroke_weight = 1
-		self.stroke_cap = 2
-		self.stroke_join = 0
-
-		## Renderer Globals
-		## VIEW MATRICES, ETC
-		##
-		self.viewport = None
-		self.texture_viewport = None
-		self.transform_matrix = np.identity(4)
 		self.modelview_matrix = np.identity(4)
-		self.projection_matrix = np.identity(4)
-
-		## Renderer Globals: RENDERING
-		self.draw_queue = []
 
 	def initialize_renderer(self):
 		self.fbuffer = FrameBuffer()

--- a/p5/sketch/renderer2d.py
+++ b/p5/sketch/renderer2d.py
@@ -390,10 +390,6 @@ class Renderer2D(OpenGLRenderer):
 
 		self.fbuffer_tex_front, self.fbuffer_tex_back = self.fbuffer_tex_back, self.fbuffer_tex_front
 
-
-	def _transform_vertices(self, vertices, local_matrix, global_matrix):
-		return np.dot(np.dot(vertices, local_matrix.T), global_matrix.T)[:, :3]
-
 	def _add_to_draw_queue_simple(self, stype, vertices, idx, fill, stroke, stroke_weight, stroke_cap, stroke_join):
 		"""Adds shape of stype to draw queue
 		"""

--- a/p5/sketch/renderer2d.py
+++ b/p5/sketch/renderer2d.py
@@ -38,6 +38,7 @@ from .shaders2d import src_default
 from .shaders2d import src_fbuffer
 from .shaders2d import src_texture
 from .shaders2d import src_line
+from .openglrenderer import OpenGLRenderer
 
 from OpenGL.GLU import gluTessBeginPolygon, gluTessBeginContour, gluTessEndPolygon, gluTessEndContour, gluTessVertex
 
@@ -216,7 +217,7 @@ def get_render_primitives(shape):
 			render_primitives.extend(_get_borders(shape))
 	return render_primitives
 
-class Renderer2D:
+class Renderer2D(OpenGLRenderer):
 	def __init__(self):
 		self.default_prog = None
 		self.fbuffer_prog = None
@@ -435,52 +436,6 @@ class Renderer2D:
 			current_queue = []
 
 		self.draw_queue = []
-
-	def render_default(self, draw_type, draw_queue):
-		# 1. Get the maximum number of vertices persent in the shapes
-		# in the draw queue.
-		#
-		if len(draw_queue) == 0:
-			return
-
-		num_vertices = 0
-		for vertices, _, _ in draw_queue:
-			num_vertices = num_vertices + len(vertices)
-
-		# 2. Create empty buffers based on the number of vertices.
-		#
-		data = np.zeros(num_vertices,
-						dtype=[('position', np.float32, 3),
-							   ('color', np.float32, 4)])
-
-		# 3. Loop through all the shapes in the geometry queue adding
-		# it's information to the buffer.
-		#
-		sidx = 0
-		draw_indices = []
-		for vertices, idx, color in draw_queue:
-			num_shape_verts = len(vertices)
-
-			data['position'][sidx:(sidx + num_shape_verts),] = vertices
-
-			color_array = np.array([color] * num_shape_verts)
-			data['color'][sidx:sidx + num_shape_verts, :] = color_array
-
-			draw_indices.append(sidx + idx)
-
-			sidx += num_shape_verts
-
-		self.vertex_buffer.set_data(data)
-		self.index_buffer.set_data(np.hstack(draw_indices))
-
-		# 4. Bind the buffer to the shader.
-		#
-		self.default_prog.bind(self.vertex_buffer)
-
-		# 5. Draw the shape using the proper shape type and get rid of
-		# the buffers.
-		#
-		self.default_prog.draw(draw_type, indices=self.index_buffer)
 
 	def render_line(self, queue):
 		'''

--- a/p5/sketch/renderer2d.py
+++ b/p5/sketch/renderer2d.py
@@ -559,8 +559,6 @@ class Renderer2D(OpenGLRenderer):
 		program is about to exit.
 
 		"""
-		self.default_prog.delete()
-		self.fbuffer_prog.delete()
+		OpenGLRenderer.cleanup()
 		self.line_prog.delete()
-		self.fbuffer.delete()
 

--- a/p5/sketch/renderer3d.py
+++ b/p5/sketch/renderer3d.py
@@ -41,8 +41,9 @@ from ..core.geometry import Geometry
 from ..core.shape import PShape
 
 from ..pmath.matrix import translation_matrix
+from .openglrenderer import OpenGLRenderer
 
-class Renderer3D:
+class Renderer3D(OpenGLRenderer):
 	def __init__(self):
 		self.default_prog = None
 
@@ -320,52 +321,6 @@ class Renderer3D:
 			current_queue = []
 
 		self.draw_queue = []
-
-	def render_default(self, draw_type, draw_queue):
-		# 1. Get the maximum number of vertices persent in the shapes
-		# in the draw queue.
-		#
-		if len(draw_queue) == 0:
-			return
-
-		num_vertices = 0
-		for vertices, _, _ in draw_queue:
-			num_vertices = num_vertices + len(vertices)
-
-		# 2. Create empty buffers based on the number of vertices.
-		#
-		data = np.zeros(num_vertices,
-						dtype=[('position', np.float32, 3),
-							   ('color', np.float32, 4)])
-
-		# 3. Loop through all the shapes in the geometry queue adding
-		# it's information to the buffer.
-		#
-		sidx = 0
-		draw_indices = []
-		for vertices, idx, color in draw_queue:
-			num_shape_verts = len(vertices)
-
-			data['position'][sidx:(sidx + num_shape_verts),] = np.array(vertices)
-
-			color_array = np.array([color] * num_shape_verts)
-			data['color'][sidx:sidx + num_shape_verts, :] = color_array
-
-			draw_indices.append(sidx + idx)
-
-			sidx += num_shape_verts
-
-		self.vertex_buffer.set_data(data)
-		self.index_buffer.set_data(np.hstack(draw_indices))
-
-		# 4. Bind the buffer to the shader.
-		#
-		self.default_prog.bind(self.vertex_buffer)
-
-		# 5. Draw the shape using the proper shape type and get rid of
-		# the buffers.
-		#
-		self.default_prog.draw(draw_type, indices=self.index_buffer)
 
 	def cleanup(self):
 		"""Run the clean-up routine for the renderer.

--- a/p5/sketch/renderer3d.py
+++ b/p5/sketch/renderer3d.py
@@ -24,19 +24,11 @@ from ..pmath import matrix
 import builtins
 
 from vispy import gloo
-from vispy.gloo import FrameBuffer
-from vispy.gloo import IndexBuffer
-from vispy.gloo import Program
 from vispy.gloo import Texture2D
-from vispy.gloo import VertexBuffer
 
 from contextlib import contextmanager
 
 from ..core.constants import Z_EPSILON
-
-from .shaders3d import src_default
-from .shaders3d import src_fbuffer
-
 from ..core.geometry import Geometry
 from ..core.shape import PShape
 
@@ -49,31 +41,7 @@ class Renderer3D(OpenGLRenderer):
 		self.lookat_matrix = np.identity(4)
 
 	def initialize_renderer(self):
-		self.fbuffer = FrameBuffer()
-
-		vertices = np.array([[-1.0, -1.0],
-							 [+1.0, -1.0],
-							 [-1.0, +1.0],
-							 [+1.0, +1.0]],
-							np.float32)
-		texcoords = np.array([[0.0, 0.0],
-							  [1.0, 0.0],
-							  [0.0, 1.0],
-							  [1.0, 1.0]],
-							 dtype=np.float32)
-
-		self.fbuf_vertices = VertexBuffer(data=vertices)
-		self.fbuf_texcoords = VertexBuffer(data=texcoords)
-
-		self.fbuffer_prog = Program(src_fbuffer.vert, src_fbuffer.frag)
-		self.fbuffer_prog['texcoord'] = self.fbuf_texcoords
-		self.fbuffer_prog['position'] = self.fbuf_vertices
-
-		self.vertex_buffer = VertexBuffer()
-		self.index_buffer = IndexBuffer()
-
-		self.default_prog = Program(src_default.vert, src_default.frag)
-
+		super().initialize_renderer()
 		self.reset_view()
 
 	def reset_view(self):

--- a/p5/sketch/renderer3d.py
+++ b/p5/sketch/renderer3d.py
@@ -200,9 +200,6 @@ class Renderer3D(OpenGLRenderer):
 
 		self.fbuffer_tex_front, self.fbuffer_tex_back = self.fbuffer_tex_back, self.fbuffer_tex_front
 
-	def _transform_vertices(self, vertices, local_matrix, global_matrix):
-		return np.dot(np.dot(vertices, local_matrix.T), global_matrix.T)[:, :3]
-
 	def render(self, shape):
 		if isinstance(shape, Geometry):
 			n = len(shape.vertices)

--- a/p5/sketch/renderer3d.py
+++ b/p5/sketch/renderer3d.py
@@ -321,15 +321,3 @@ class Renderer3D(OpenGLRenderer):
 			current_queue = []
 
 		self.draw_queue = []
-
-	def cleanup(self):
-		"""Run the clean-up routine for the renderer.
-
-		This method is called when all drawing has been completed and the
-		program is about to exit.
-
-		"""
-		self.default_prog.delete()
-		self.fbuffer_prog.delete()
-		self.fbuffer.delete()
-

--- a/p5/sketch/renderer3d.py
+++ b/p5/sketch/renderer3d.py
@@ -45,49 +45,8 @@ from .openglrenderer import OpenGLRenderer
 
 class Renderer3D(OpenGLRenderer):
 	def __init__(self):
-		self.default_prog = None
-
-		self.fbuffer = None
-		self.fbuffer_tex_front = None
-		self.fbuffer_tex_back = None
-
-		self.vertex_buffer = None
-		self.index_buffer = None
-
-		## Renderer Globals: USEFUL CONSTANTS
-		self.COLOR_WHITE = (1, 1, 1, 1)
-		self.COLOR_BLACK = (0, 0, 0, 1)
-		self.COLOR_DEFAULT_BG = (0.8, 0.8, 0.8, 1.0)
-
-		## Renderer Globals: STYLE/MATERIAL PROPERTIES
-		##
-		self.background_color = self.COLOR_DEFAULT_BG
-
-		self.fill_color = self.COLOR_WHITE
-		self.fill_enabled = True
-
-		self.stroke_color = self.COLOR_BLACK
-		self.stroke_enabled = True
-
-		self.tint_color = self.COLOR_BLACK
-		self.tint_enabled = False
-
-		## Renderer Globals: Curves
-		self.stroke_weight = 1
-		self.stroke_cap = 2
-		self.stroke_join = 0
-
-		## Renderer Globals
-		## VIEW MATRICES, ETC
-		##
-		self.viewport = None
-		self.texture_viewport = None
-		self.transform_matrix = np.identity(4)
-		self.projection_matrix = np.identity(4)
+		super().__init__()
 		self.lookat_matrix = np.identity(4)
-
-		## Renderer Globals: RENDERING
-		self.draw_queue = []
 
 	def initialize_renderer(self):
 		self.fbuffer = FrameBuffer()


### PR DESCRIPTION
OpenGLRenderer is an abstract class that contains some of the common logic shared by the renderers that use vispy/opengl. It cannot be instantiated directly and is inherited by both Renderer2D and Renderer3D.