### PR TITLE
Close contour automatically

### DIFF
--- a/p5/core/vertex.py
+++ b/p5/core/vertex.py
@@ -207,6 +207,10 @@ def begin_contour():
 def end_contour():
 	global is_contour, curr_contour_vertices, curr_contour_vertices_types
 	is_contour = False
+	# Close contour
+	curr_contour_vertices.append(curr_contour_vertices[0])
+	curr_contour_vertices_types.append(curr_contour_vertices_types[0])
+	# Save contour
 	contour_vertices.append(curr_contour_vertices)
 	contour_vertices_types.append(curr_contour_vertices_types)
 	curr_contour_vertices, curr_contour_vertices_types = [], []


### PR DESCRIPTION
Unlike `end_shape`, `end_contour` does not have an optional parameter `'CLOSE'`. Therefore, the default behavior should be closing the contour automatically.

Fixes #195 

<img width="570" alt="Screen Shot 2020-07-12 at 3 34 17 PM" src="https://user-images.githubusercontent.com/18119047/87258024-2b8ac380-c455-11ea-983a-e96c563730c5.png">
