### PR TITLE
Create global variables for enum SType

### DIFF
--- a/docs/examples/form/triangle strip.rst
+++ b/docs/examples/form/triangle strip.rst
@@ -70,7 +70,7 @@ Example by Ira Greenberg. Generate a closed ring using the vertex() function and
 		angle = 0
 		angleStep = 180.0 / numPoints
 
-		begin_shape("TRIANGLE_STRIP")
+		begin_shape(TRIANGLE_STRIP)
 
 		for i in range(numPoints + 1):
 			px = x + cos(radians(angle)) * outsideRadius

--- a/docs/examples/input/clock.rst
+++ b/docs/examples/input/clock.rst
@@ -122,7 +122,7 @@ The current time can be read with the second(), minute(), and hour() functions. 
 
 		# Draw the minute ticks
 		stroke_weight(2)
-		begin_shape("POINTS")
+		begin_shape(POINTS)
 		for a in range(0, 360, 6):
 			angle = radians(a)
 			x = cx + cos(angle) * secondsRadius

--- a/p5/core/constants.py
+++ b/p5/core/constants.py
@@ -187,8 +187,8 @@ colour_codes = {
 	'black': '#000000',
 }
 
+
 # Shape types / kinds
-# POINTS, LINES, TRIANGLES, TRIANGLE_FAN TRIANGLE_STRIP, QUADS, or QUAD_STRIP
 class SType(Enum):
 	POINTS = 'POINTS'
 	LINES = 'LINES'
@@ -200,6 +200,22 @@ class SType(Enum):
 	QUAD_STRIP = 'QUAD_STRIP'
 	TESS = 'TESS'
 
+
+# Add all members of SType to global
+# One way to do the same thing but without auto-complete from editors
+#       globals().update(SType.__members__)
+POINTS = SType.POINTS
+LINES = SType.LINES
+LINE_STRIP = SType.LINE_STRIP
+TRIANGLES = SType.TRIANGLES
+TRIANGLE_FAN = SType.TRIANGLE_FAN
+TRIANGLE_STRIP = SType.TRIANGLE_STRIP
+QUADS = SType.QUADS
+QUAD_STRIP = SType.QUAD_STRIP
+TESS = SType.TESS
+
+# end_shape parameters
+CLOSE = "CLOSE"
+
 # Z_EPSILON for meshes and lines in 3D mode
 Z_EPSILON = 2
-

--- a/p5/core/vertex.py
+++ b/p5/core/vertex.py
@@ -19,7 +19,7 @@
 from . import p5
 from . import primitives
 from .shape import PShape
-from .constants import SType
+from .constants import TESS
 from ..pmath import curves
 
 shape_kind = None
@@ -35,23 +35,19 @@ is_quadratic = False
 is_contour = False
 
 __all__ = ['begin_shape', 'end_shape', 'begin_contour', 'end_contour',
-		   'curve_vertex', 'bezier_vertex', 'quadratic_vertex', 'vertex']
+           'curve_vertex', 'bezier_vertex', 'quadratic_vertex', 'vertex']
 
-def begin_shape(kind=None):
-	"""
-	Begin shape drawing.  This is a helpful way of generating custom shapes quickly.
 
-	:param kind: POINTS, LINES, TRIANGLES, TRIANGLE_FAN TRIANGLE_STRIP, QUADS, or QUAD_STRIP
-	:type kind: str
+def begin_shape(kind=TESS):
+	"""Begin shape drawing.  This is a helpful way of generating custom shapes quickly.
+
+	:param kind: TESS, POINTS, LINES, TRIANGLES, TRIANGLE_FAN, TRIANGLE_STRIP, QUADS, or QUAD_STRIP; defaults to TESS
+	:type kind: SType
 	"""
 	global shape_kind, vertices, contour_vertices, vertices_types, contour_vertices_types, is_contour
 	global curr_contour_vertices, curr_contour_vertices_types
 
-	if kind in (t.name for t in SType):
-		shape_kind = SType[kind]
-	else:
-		shape_kind = SType.TESS
-
+	shape_kind = kind
 	is_contour = False
 	vertices = []
 	vertices_types = []
@@ -205,6 +201,10 @@ def begin_contour():
 	contour_vertices_types = []
 
 def end_contour():
+	"""Ends the current contour.
+
+	For more info, see :any:`begin_contour`.
+	"""
 	global is_contour, curr_contour_vertices, curr_contour_vertices_types
 	is_contour = False
 	# Close contour
@@ -301,7 +301,7 @@ def end_shape(mode=""):
 	global is_bezier, is_curve, is_quadratic, is_contour
 	assert not is_contour, "begin_contour called without calling end_contour"
 	if is_curve or is_bezier or is_quadratic:
-		assert shape_kind == SType.TESS, "Should not specify primitive type for a curve"
+		assert shape_kind == TESS, "Should not specify primitive type for a curve"
 
 	if len(vertices) == 0:
 		return
@@ -319,17 +319,17 @@ def end_shape(mode=""):
 		if len(vertices) > 3:
 			shape = PShape(vertices=get_curve_vertices(vertices),
 						   contours=[get_curve_vertices(c) for c in contour_vertices],
-						   shape_type=SType.TESS)
+						   shape_type=TESS)
 	elif is_bezier:
 		shape = PShape(vertices=get_bezier_vertices(vertices, vertices_types),
 					   contours=[get_bezier_vertices(contour_vertices[i], contour_vertices_types[i])
                                  for i in range(len(contour_vertices))],
-					   shape_type=SType.TESS)
+					   shape_type=TESS)
 	elif is_quadratic:
 		shape = PShape(vertices=get_quadratic_vertices(vertices, vertices_types),
 					   contours=[get_quadratic_vertices(contour_vertices[i], contour_vertices_types[i])
                                  for i in range(len(contour_vertices))],
-					   shape_type=SType.TESS)
+					   shape_type=TESS)
 	else:
 		shape = PShape(vertices=vertices, contours=contour_vertices, shape_type=shape_kind)
 

--- a/profiling/custom_shapes2.py
+++ b/profiling/custom_shapes2.py
@@ -4,7 +4,7 @@ def setup():
         size(720, 400)
 
 def draw():
-        begin_shape('TRIANGLES')
+        begin_shape(TRIANGLES)
         vertex(30, 75)
         vertex(40, 20)
         vertex(50, 75)
@@ -13,7 +13,7 @@ def draw():
         vertex(80, 20)
         end_shape()
 
-        begin_shape('TRIANGLE_FAN')
+        begin_shape(TRIANGLE_FAN)
         vertex(157.5, 50)
         vertex(157.5, 15)
         vertex(192, 50)
@@ -22,7 +22,7 @@ def draw():
         vertex(157.5, 15)
         end_shape()
 
-        begin_shape('QUAD_STRIP')
+        begin_shape(QUAD_STRIP)
         vertex(230, 20)
         vertex(230, 75)
         vertex(250, 20)
@@ -33,7 +33,7 @@ def draw():
         vertex(285, 75)
         end_shape()
 
-        begin_shape('QUADS')
+        begin_shape(QUADS)
         vertex(330, 20)
         vertex(330, 75)
         vertex(350, 75)
@@ -44,7 +44,7 @@ def draw():
         vertex(385, 20)
         end_shape()
 
-        begin_shape('LINES')
+        begin_shape(LINES)
         vertex(30, 120)
         vertex(85, 120)
         vertex(85, 175)
@@ -64,10 +64,10 @@ def draw():
         vertex(285, 120)
         vertex(285, 175)
         vertex(230, 175)
-        end_shape('CLOSE')
+        end_shape(CLOSE)
         fill(255, 255, 255)
 
-        begin_shape('TRIANGLE_STRIP')
+        begin_shape(TRIANGLE_STRIP)
         vertex(330, 175)
         vertex(340, 120)
         vertex(350, 175)
@@ -84,7 +84,7 @@ def draw():
         vertex(60, 240)
         vertex(60, 260)
         vertex(20, 260)
-        end_shape('CLOSE')
+        end_shape(CLOSE)
 
 if __name__ == '__main__':
         run()

--- a/profiling/triangle_strip.py
+++ b/profiling/triangle_strip.py
@@ -21,7 +21,7 @@ def draw():
         angle = 0
         angleStep = 180.0 / numPoints
 
-        begin_shape("TRIANGLE_STRIP")
+        begin_shape(TRIANGLE_STRIP)
 
         for i in range(numPoints + 1):
                 px = x + cos(radians(angle)) * outsideRadius


### PR DESCRIPTION
Now instead of calling `begin_shape("TRIANGLE")`, one can use `begin_shape(TRIANGLE)`, which is more consistent compared to other processing dialects.
