### PR TITLE
Fixed issue #183

### DIFF
--- a/p5/core/shape.py
+++ b/p5/core/shape.py
@@ -386,10 +386,10 @@ class PShape:
         :rtype: np.ndarray
 
         """
-        if (not sy) and (not sz):
+        if sy is None and sz is None:
             sy = sx
             sz = sx
-        elif not sz:
+        elif sz is None:
             sz = 1
         tmat = matrix.scale_transform(sx, sy, sz)
         return tmat

--- a/p5/core/transforms.py
+++ b/p5/core/transforms.py
@@ -139,10 +139,10 @@ def scale(sx, sy=None, sz=None):
     :returns: The transformation matrix used to appy the transformation.
     :rtype: np.ndarray
     """
-    if (not sy) and (not sz):
+    if sy is None and sz is None:
         sy = sx
         sz = sx
-    elif not sz:
+    elif sz is None:
         sz = 1
     tmat = matrix.scale_transform(sx, sy, sz)
     p5.renderer.transform_matrix = p5.renderer.transform_matrix.dot(tmat)


### PR DESCRIPTION
The intended behavior was to scale sy and sz the same about as sx, if sx was the only variable not None. `not 0` returns True in python. That is why `scale(0, 1)` worked but `scale(1, 0)` didn't.