### PR TITLE
Normalize colors in 3D mode

### DIFF
--- a/p5/core/color.py
+++ b/p5/core/color.py
@@ -276,6 +276,11 @@ class Color:
         return (self._red, self._green, self._blue, self._alpha)
 
     @property
+    def normalized_rgb(self):
+        """Normalized RGB color values"""
+        return (self._red, self._green, self._blue)
+
+    @property
     def gray(self):
         """The gray-scale value of the color.
 

--- a/p5/core/light.py
+++ b/p5/core/light.py
@@ -1,4 +1,4 @@
-from . import p5
+from . import p5, Color
 from ..sketch.util import ensure_p3d
 import numpy as np
 
@@ -31,7 +31,7 @@ def ambient_light(r, g, b):
     :type b: float
     """
     ensure_p3d('ambient_light')
-    p5.renderer.add_ambient_light(r, g, b)
+    p5.renderer.add_ambient_light(*Color(r, g, b).normalized_rgb)
 
 
 def directional_light(r, g, b, x, y, z):
@@ -59,7 +59,7 @@ def directional_light(r, g, b, x, y, z):
     :type z: float
     """
     ensure_p3d('directional_light')
-    p5.renderer.add_directional_light(r, g, b, x, y, z)
+    p5.renderer.add_directional_light(*Color(r, g, b).normalized_rgb, x, y, z)
 
 
 def point_light(r, g, b, x, y, z):
@@ -85,7 +85,7 @@ def point_light(r, g, b, x, y, z):
     :type z: float
     """
     ensure_p3d('point_light')
-    p5.renderer.add_point_light(r, g, b, x, y, z)
+    p5.renderer.add_point_light(*Color(r, g, b).normalized_rgb, x, y, z)
 
 
 def light_falloff(constant, linear, quadratic):
@@ -132,4 +132,4 @@ def light_specular(r, g, b):
     :type b: float
     """
     ensure_p3d('light_specular')
-    p5.renderer.light_specular = np.array([r, g, b])
+    p5.renderer.light_specular = np.array(Color(r, g, b).normalized_rgb)

--- a/p5/core/material.py
+++ b/p5/core/material.py
@@ -1,4 +1,4 @@
-from . import p5, fill
+from . import p5, fill, Color
 from ..sketch.util import ensure_p3d
 import numpy as np
 
@@ -86,7 +86,7 @@ def ambient(r, g, b):
     :type b: float
     """
     ensure_p3d('ambient')
-    p5.renderer.ambient = np.array((r, g, b), dtype=np.float32)
+    p5.renderer.ambient = np.array(Color(r, g, b).normalized_rgb, dtype=np.float32)
 
 
 def emissive(r, g, b):
@@ -102,7 +102,7 @@ def emissive(r, g, b):
     :type b: float
     """
     ensure_p3d('emissive')
-    return diffuse(r, g, b)
+    return diffuse(*Color(r, g, b).normalized_rgb)
 
 
 def diffuse(r, g, b):
@@ -118,7 +118,7 @@ def diffuse(r, g, b):
     :type b: float
     """
     ensure_p3d('diffuse')
-    p5.renderer.diffuse = np.array((r, g, b), dtype=np.float32)
+    p5.renderer.diffuse = np.array(Color(r, g, b).normalized_rgb, dtype=np.float32)
 
 
 def shininess(p):
@@ -139,6 +139,6 @@ def specular(r, g, b):
     Should be used together with :any:`light_specular`.
     """
     ensure_p3d('specular')
-    p5.renderer.specular = np.array((r, g, b), dtype=np.float32)
+    p5.renderer.specular = np.array(Color(r, g, b).normalized_rgb, dtype=np.float32)
 
 # TODO: Document default values for material functions in renderer3D


### PR DESCRIPTION
Colors in OpenGL are on a scale of 0.0 to 1.0, which is different from
the scale of 0.0 to 255.0 that p5py typically uses. This PR implements
a new normalized_rgb method in Color and uses it to preprocess colors
in 3D APIs.