### PR TITLE
Add additional signatures for `line`, `circle`, `ellipse`, and `arc`

### DIFF
--- a/docs/reference/shape.rst
+++ b/docs/reference/shape.rst
@@ -42,7 +42,7 @@ ellipse()
 circle()
 --------
 
-.. function:: circle(x, y, d)
+.. function:: circle(x, y, radius, mode=None)
    :noindex:
 .. autofunction:: circle(coordinate, radius, mode=None)
 

--- a/docs/reference/shape.rst
+++ b/docs/reference/shape.rst
@@ -34,13 +34,17 @@ line()
 ellipse()
 ---------
 
-.. autofunction:: ellipse
+.. function:: ellipse(a, b, c, d)
+   :noindex:
+.. autofunction:: ellipse(coordinate, *args, mode=None)
 
 
 circle()
 --------
 
-.. autofunction:: circle
+.. function:: circle(x, y, d)
+   :noindex:
+.. autofunction:: circle(coordinate, radius, mode=None)
 
 
 arc()

--- a/docs/reference/shape.rst
+++ b/docs/reference/shape.rst
@@ -24,7 +24,11 @@ point()
 line()
 ------
 
-.. autofunction:: line
+.. function:: line(x1, y1, x2, y2)
+   :noindex:
+.. function:: line(x1, y1, z1, x2, y2, z2)
+   :noindex:
+.. autofunction:: line(p1, p2)
 
 
 ellipse()

--- a/docs/reference/shape.rst
+++ b/docs/reference/shape.rst
@@ -34,7 +34,7 @@ line()
 ellipse()
 ---------
 
-.. function:: ellipse(a, b, c, d)
+.. function:: ellipse(a, b, c, d, mode=None)
    :noindex:
 .. autofunction:: ellipse(coordinate, *args, mode=None)
 
@@ -50,7 +50,9 @@ circle()
 arc()
 -----
 
-.. autofunction:: arc
+.. function:: arc(x, y, width, height, start_angle, stop_angle, mode=None, ellipse_mode=None)
+   :noindex:
+.. autofunction:: arc(coordinate, width, height, start_angle, stop_angle, mode=None, ellipse_mode=None)
 
 
 triangle()

--- a/p5/core/primitives.py
+++ b/p5/core/primitives.py
@@ -543,9 +543,6 @@ def circle(*args, mode=None):
     :param y: y-coordinate of the centre of the circle.
     :type y: float
 
-    :param d: diameter of the circle.
-    :type d: float
-
     :param coordinate: Represents the center of the ellipse when mode
         is 'CENTER' (the default) or 'RADIUS', the lower-left corner
         of the ellipse when mode is 'CORNER' or, and an arbitrary

--- a/p5/core/primitives.py
+++ b/p5/core/primitives.py
@@ -416,15 +416,20 @@ def rect_mode(mode='CORNER'):
     _rect_mode = mode
 
 @_draw_on_return
-def arc(coordinate, width, height, start_angle, stop_angle,
-        mode=None, ellipse_mode=None):
+def arc(*args, mode=None, ellipse_mode=None):
     """Return a ellipse.
+
+    :param x: x-coordinate of the arc's ellipse.
+    :type x: float
+
+    :param y: y-coordinate of the arc's ellipse.
+    :type y: float
 
     :param coordinate: Represents the center of the arc when mode
         is 'CENTER' (the default) or 'RADIUS', the lower-left corner
         of the ellipse when mode is 'CORNER'.
 
-    :rtype coordinate: 3-tuple
+    :type coordinate: 3-tuple
 
     :param width: For ellipse modes 'CORNER' or 'CENTER' this
         represents the width of the the ellipse of which the arc is a
@@ -454,6 +459,13 @@ def arc(coordinate, width, height, start_angle, stop_angle,
     :rtype: Arc
 
     """
+    if len(args) == 5:
+        coordinate, width, height, start_angle, stop_angle = args
+    elif len(args) == 6:
+        coordinate = args[:2]
+        width, height, start_angle, stop_angle = args[2:]
+    else:
+        raise ValueError("Unexpected number of arguments passed to arc()")
 
     if ellipse_mode is None:
         emode = _ellipse_mode
@@ -513,8 +525,8 @@ def ellipse(*args, mode=None):
     :rtype: Arc
 
     """
-    if len(args) == 2:
-        coordinate, args = args[0], args[1]
+    if len(args) == 3:
+        coordinate, args = args[0], args[1:]
     elif len(args) == 4:
         coordinate, args = args[:2], args[2:]
     else:

--- a/p5/core/primitives.py
+++ b/p5/core/primitives.py
@@ -150,9 +150,28 @@ def point(x, y, z=0):
     """
     return PShape([(x, y, z)])
 
+
 @_draw_on_return
-def line(p1, p2):
+def line(*args):
     """Returns a line.
+
+    :param x1: x-coordinate of the first point
+    :type x1: float
+
+    :param y1: y-coordinate of the first point
+    :type y1: float
+
+    :param z1: z-coordinate of the first point
+    :type z1: float
+
+    :param x2: x-coordinate of the first point
+    :type x2: float
+
+    :param y2: y-coordinate of the first point
+    :type y2: float
+
+    :param z2: z-coordinate of the first point
+    :type z2: float
 
     :param p1: Coordinates of the starting point of the line.
     :type p1: tuple
@@ -164,6 +183,15 @@ def line(p1, p2):
     :rtype: PShape
 
     """
+    if len(args) == 2:
+        p1, p2 = args[0], args[1]
+    elif len(args) == 4:
+        p1, p2 = args[:2], args[2:]
+    elif len(args) == 6:
+        p1, p2 = args[:3], args[3:]
+    else:
+        raise ValueError("Unexpected number of arguments passed to line()")
+
     path = [
         Point(*p1),
         Point(*p2)

--- a/p5/core/primitives.py
+++ b/p5/core/primitives.py
@@ -474,8 +474,20 @@ def arc(coordinate, width, height, start_angle, stop_angle,
         raise ValueError("Unknown arc mode {}".format(emode))
     return Arc(center, dim, start_angle, stop_angle, mode)
 
-def ellipse(coordinate, *args, mode=None):
+def ellipse(*args, mode=None):
     """Return a ellipse.
+
+    :param a: x-coordinate of the ellipse
+    :type a: float
+
+    :param b: y-coordinate of the ellipse
+    :type b: float
+
+    :param c: width of the ellipse
+    :type c: float
+
+    :param d: height of the ellipse
+    :type d: float
 
     :param coordinate: Represents the center of the ellipse when mode
         is 'CENTER' (the default) or 'RADIUS', the lower-left corner
@@ -501,6 +513,13 @@ def ellipse(coordinate, *args, mode=None):
     :rtype: Arc
 
     """
+    if len(args) == 2:
+        coordinate, args = args[0], args[1]
+    elif len(args) == 4:
+        coordinate, args, mode = args[:2], args[2:], 'CENTER'
+    else:
+        raise ValueError("Unexpected number of arguments passed to ellipse()")
+
     if mode is None:
         mode = _ellipse_mode
 

--- a/p5/core/primitives.py
+++ b/p5/core/primitives.py
@@ -534,8 +534,17 @@ def ellipse(*args, mode=None):
         width, height = args
     return arc(coordinate, width, height, 0, math.pi * 2, 'CHORD', mode)
 
-def circle(coordinate, radius, mode=None):
+def circle(*args, mode=None):
     """Return a circle.
+
+    :param x: x-coordinate of the centre of the circle.
+    :type x: float
+
+    :param y: y-coordinate of the centre of the circle.
+    :type y: float
+
+    :param d: diameter of the circle.
+    :type d: float
 
     :param coordinate: Represents the center of the ellipse when mode
         is 'CENTER' (the default) or 'RADIUS', the lower-left corner
@@ -548,7 +557,7 @@ def circle(coordinate, radius, mode=None):
         represents the diameter; for the 'RADIUS' this represents the
         radius.
 
-    :type: tuple
+    :type radius: float
 
     :param mode: The drawing mode for the ellipse. Should be one of
         {'CORNER', 'CORNERS', 'CENTER', 'RADIUS'} (defaults to the
@@ -562,6 +571,13 @@ def circle(coordinate, radius, mode=None):
     :raises ValueError: When mode is set to 'CORNERS'
 
     """
+    if len(args) == 2:
+        coordinate, radius = args[0], args[1]
+    elif len(args) == 3:
+        coordinate, radius, mode = args[:2], args[2], 'CENTER'
+    else:
+        raise ValueError("Unexpected number of arguments passed to circle()")
+
     if mode is None:
         mode = _ellipse_mode
 

--- a/p5/core/primitives.py
+++ b/p5/core/primitives.py
@@ -516,7 +516,7 @@ def ellipse(*args, mode=None):
     if len(args) == 2:
         coordinate, args = args[0], args[1]
     elif len(args) == 4:
-        coordinate, args, mode = args[:2], args[2:], 'CENTER'
+        coordinate, args = args[:2], args[2:]
     else:
         raise ValueError("Unexpected number of arguments passed to ellipse()")
 
@@ -574,7 +574,7 @@ def circle(*args, mode=None):
     if len(args) == 2:
         coordinate, radius = args[0], args[1]
     elif len(args) == 3:
-        coordinate, radius, mode = args[:2], args[2], 'CENTER'
+        coordinate, radius = args[:2], args[2]
     else:
         raise ValueError("Unexpected number of arguments passed to circle()")
 

--- a/p5/core/primitives.py
+++ b/p5/core/primitives.py
@@ -544,7 +544,7 @@ def ellipse(*args, mode=None):
         mode = 'CORNER'
     else:
         width, height = args
-    return arc(coordinate, width, height, 0, math.pi * 2, 'CHORD', mode)
+    return arc(coordinate, width, height, 0, math.pi * 2, mode='CHORD', ellipse_mode=mode)
 
 def circle(*args, mode=None):
     """Return a circle.

--- a/profiling/arcs.py
+++ b/profiling/arcs.py
@@ -8,9 +8,9 @@ def draw():
     x = 0
     while x < 2 * PI:
         arc((50.0 + offset, 50.0), 50.0, 50.0, x, 2 * PI)
-        arc((50.0 + offset, 100), 50, 50, x, 2 * PI, 'OPEN')
-        arc((50.0 + offset, 150), 50, 50, x, 2 * PI, 'CHORD')
-        arc((50.0 + offset, 200), 50, 50, x, 2 * PI, 'PIE')
+        arc((50.0 + offset, 100), 50, 50, x, 2 * PI, mode='OPEN')
+        arc((50.0 + offset, 150), 50, 50, x, 2 * PI, mode='CHORD')
+        arc((50.0 + offset, 200), 50, 50, x, 2 * PI, mode='PIE')
         x += QUARTER_PI
         offset += 50
 


### PR DESCRIPTION
Partially addresses #130
New signatures:
* `line(x1, y1, x2, y2)`
* `line(x1, y1, z1, x2, y2, z2)`
* `ellipse(a, b, c, d, mode=None)`
* `circle(x, y, radius, mode=None)`
* `arc(x, y, width, height, start_angle, stop_angle, mode=None, ellipse_mode=None)`
