### PR TITLE
Add more sample scenes to profile

### DIFF
--- a/profiling/README.md
+++ b/profiling/README.md
@@ -1,0 +1,5 @@
+### Profiling
+
+The provided profiling script uses the built-in Python cProfile module. To start profiling, run `python main.py`. This will render each sample scene listed in `main.py` for 100 frames and write profiling information as .prof files. They can then be opened by programs such as snakeviz.
+
+Because the existing Python harness is unstable due to possible global states not being cleaned up properly, a bash harness is in the works. As of now this harness does not output profiling information but merely runs each scene for 3 seconds. Can be useful for integration testing. Use `./main.sh` to run.

--- a/profiling/begin_contour.py
+++ b/profiling/begin_contour.py
@@ -1,0 +1,25 @@
+from p5 import *
+
+def setup():
+    size(640, 360)
+    no_loop()
+
+def draw():
+	translate(50, 50)
+	stroke(255, 0, 0)
+	begin_shape()
+	# Exterior part of shape, clockwise winding
+	vertex(-40, -40)
+	vertex(40, -40)
+	vertex(40, 40)
+	vertex(-40, 40)
+	# # Interior part of shape, counter-clockwise winding
+	begin_contour()
+	vertex(-20, -20)
+	vertex(-20, 20)
+	vertex(20, 20)
+	vertex(20, -20)
+	end_contour()
+	end_shape('CLOSE')
+
+run(mode="P2D")

--- a/profiling/main.sh
+++ b/profiling/main.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+FILES=*.py
+for f in $FILES
+do
+    if [[ "$f" != "main.py" ]]; then
+        echo "Running $f"
+        timeout 3 python $f
+        echo "Finished $f"
+    fi
+done

--- a/profiling/spinning-cone.py
+++ b/profiling/spinning-cone.py
@@ -1,0 +1,24 @@
+from p5 import *
+
+def setup():
+    size(720, 400)
+
+def draw():
+    background(205, 102, 94)
+    rotate_x(frame_count * 0.02)
+    rotate_y(frame_count * 0.01)
+    blinn_phong_material()
+    # normal_material()
+    cone(200, 400)
+    # box(100, 100, 100)
+    ### Begin LIGHTS
+    # directional_light(1, 1, 1, 0, 0, -1)
+    locX = mouse_x - width/2
+    locY = mouse_y - height/2
+    light_specular(0, 0, 255)
+    point_light(360, 360*1.5, 360, locX, locY, 400)
+    ### End LIGHTS
+    # cone(200, 400)
+
+if __name__ == '__main__':
+    run(mode='P3D')

--- a/profiling/tetrahedron.py
+++ b/profiling/tetrahedron.py
@@ -1,0 +1,32 @@
+from p5 import *
+
+def setup():
+    size(640, 360)
+    no_loop()
+
+def draw():
+    background(0)
+
+    stroke(255)
+    rotate_x(PI*3/2)
+    rotate_z(PI/6)
+    fill(255)
+    begin_shape()
+    vertex(-100, -100, -100)
+    vertex( 100, -100, -100)
+    vertex(   0,    0,  100)
+
+    vertex( 100, -100, -100)
+    vertex( 100,  100, -100)
+    vertex(   0,    0,  100)
+
+    vertex( 100, 100, -100)
+    vertex(-100, 100, -100)
+    vertex(   0,   0,  100)
+
+    vertex(-100,  100, -100)
+    vertex(-100, -100, -100)
+    vertex(   0,    0,  100)
+    end_shape()
+
+run(mode='P3D')


### PR DESCRIPTION
Adds more sample scenes in the `profiling` folder.
Also includes a simple bash harness to run all the scenes because the previous python one does not always work possibly due to some global state being preserved between scenes.