### PR TITLE
pylint now runs on PRs

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,6 +17,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pylint
+        pip install -r requirements.txt
     - name: Test with pytest
       run: |
         pylint `find . -name '*.py'`

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,6 +1,6 @@
 name: Pylint
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -19,4 +19,5 @@ jobs:
         pip install pylint
     - name: Test with pytest
       run: |
-        pylint `ls -R|grep .py$|xargs`
+        pylint `find . -name '*.py'`
+


### PR DESCRIPTION
@parsoyaarihant 
This should work, no module error was there in pylint occurred because we passed filenames instead of the whole path. So pylint was searching for the file only in the current directory.
Pylint job now builds on PRs as well as pushes.