### PR TITLE
Refactor begin_shape & end_shape APIs to support multiple renderers

### DIFF
--- a/p5/core/primitives.py
+++ b/p5/core/primitives.py
@@ -16,38 +16,22 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-import functools
 import math
 
 from ..pmath import Point
 from ..pmath import curves
 
 from ..sketch.Vispy2DRenderer.shape import PShape
-from .geometry import Geometry
 from .constants import ROUND, SQUARE, PROJECT
 
 from . import p5
 
 __all__ = ['point', 'line', 'arc', 'triangle', 'quad',
            'rect', 'square', 'circle', 'ellipse', 'ellipse_mode',
-           'rect_mode', 'bezier', 'curve', 'create_shape', 'draw_shape']
+           'rect_mode', 'bezier', 'curve', 'create_shape']
 
 _rect_mode = 'CORNER'
 _ellipse_mode = 'CENTER'
-
-
-def _draw_on_return(func):
-    """Set shape parameters to default renderer parameters
-
-    """
-
-    @functools.wraps(func)
-    def wrapped(*args, **kwargs):
-        s = func(*args, **kwargs)
-        draw_shape(s)
-        return s
-
-    return wrapped
 
 
 def point(x, y, z=0):
@@ -716,25 +700,6 @@ def ellipse_mode(mode='CENTER'):
     """
     global _ellipse_mode
     _ellipse_mode = mode
-
-
-def draw_shape(shape, pos=(0, 0, 0)):
-    """Draw the given shape at the specified location.
-
-    :param shape: The shape that needs to be drawn.
-    :type shape: p5.PShape
-
-    :param pos: Position of the shape
-    :type pos: tuple | Vector
-
-    """
-    p5.renderer.render(shape)
-
-    if isinstance(shape, Geometry):
-        return
-
-    for child_shape in shape.children:
-        draw_shape(child_shape)
 
 
 def create_shape(kind=None, *args, **kwargs):

--- a/p5/core/primitives3d.py
+++ b/p5/core/primitives3d.py
@@ -17,11 +17,10 @@
 #
 
 import math
-
+import functools
 from .geometry import Geometry
-
+from . import p5
 from ..pmath import matrix
-from .primitives import _draw_on_return
 
 # We use these in ellipse tessellation. The algorithm is similar to
 # the one used in Processing and the we compute the number of
@@ -44,6 +43,39 @@ from .primitives import _draw_on_return
 MIN_POINT_ACCURACY = 20
 MAX_POINT_ACCURACY = 200
 POINT_ACCURACY_FACTOR = 10
+
+
+def _draw_on_return(func):
+    """Set shape parameters to default renderer parameters
+
+    """
+
+    @functools.wraps(func)
+    def wrapped(*args, **kwargs):
+        s = func(*args, **kwargs)
+        draw_shape(s)
+        return s
+
+    return wrapped
+
+
+def draw_shape(shape, pos=(0, 0, 0)):
+    """Draw the given shape at the specified location.
+
+    :param shape: The shape that needs to be drawn.
+    :type shape: p5.PShape
+
+    :param pos: Position of the shape
+    :type pos: tuple | Vector
+
+    """
+    p5.renderer.render(shape)
+
+    if isinstance(shape, Geometry):
+        return
+
+    for child_shape in shape.children:
+        draw_shape(child_shape)
 
 
 @_draw_on_return

--- a/p5/core/vertex.py
+++ b/p5/core/vertex.py
@@ -17,8 +17,6 @@
 #
 
 from . import p5
-from . import primitives
-from p5.sketch.Vispy2DRenderer.shape import PShape
 from .constants import TESS
 from ..pmath import curves
 from p5.pmath.vector import Point
@@ -300,7 +298,6 @@ def get_quadratic_vertices(verts, vert_types):
     return shape_vertices
 
 
-@primitives._draw_on_return
 def end_shape(mode=""):
     """
     The endShape() function is the companion to beginShape()
@@ -329,25 +326,24 @@ def end_shape(mode=""):
         vertices.append(vertices[0])
         vertices_types.append(vertices_types[0])
 
-    shape = None
     if is_curve:
         if len(vertices) > 3:
-            shape = PShape(vertices=get_curve_vertices(vertices),
-                           contours=[
-                get_curve_vertices(c) for c in contour_vertices],
-                shape_type=TESS)
+            p5.renderer.shape(vertices=get_curve_vertices(vertices),
+                              contours=[
+                                  get_curve_vertices(c) for c in contour_vertices],
+                              shape_type=TESS)
     elif is_bezier:
-        shape = PShape(vertices=get_bezier_vertices(vertices, vertices_types),
-                       contours=[get_bezier_vertices(contour_vertices[i], contour_vertices_types[i])
-                                 for i in range(len(contour_vertices))],
-                       shape_type=TESS)
+        p5.renderer.shape(vertices=get_bezier_vertices(vertices, vertices_types),
+                          contours=[get_bezier_vertices(contour_vertices[i], contour_vertices_types[i])
+                                    for i in range(len(contour_vertices))],
+                          shape_type=TESS)
     elif is_quadratic:
-        shape = PShape(vertices=get_quadratic_vertices(vertices, vertices_types),
-                       contours=[get_quadratic_vertices(contour_vertices[i], contour_vertices_types[i])
-                                 for i in range(len(contour_vertices))],
-                       shape_type=TESS)
+        p5.renderer.shape(vertices=get_quadratic_vertices(vertices, vertices_types),
+                          contours=[get_quadratic_vertices(contour_vertices[i], contour_vertices_types[i])
+                                    for i in range(len(contour_vertices))],
+                          shape_type=TESS)
     else:
-        shape = PShape(
+        p5.renderer.shape(
             vertices=vertices,
             contours=contour_vertices,
             shape_type=shape_kind)
@@ -356,5 +352,3 @@ def end_shape(mode=""):
     is_curve = False
     is_quadratic = False
     is_contour = False
-
-    return shape

--- a/p5/sketch/Vispy2DRenderer/renderer2d.py
+++ b/p5/sketch/Vispy2DRenderer/renderer2d.py
@@ -373,3 +373,7 @@ class VispyRenderer2D(OpenGLRenderer):
         mode = args[4]
 
         self.render_shape(Arc(center, dim, start_angle, stop_angle, mode))
+
+    def shape(self, vertices, contours, shape_type, *args):
+        """Draws the shape made using begin_shape and end_shape"""
+        self.render_shape(PShape(vertices=vertices, contours=contours, shape_type=shape_type))


### PR DESCRIPTION
Related to #214 
`end_shape` now calls `p5.renderer.shape()` and passes the required data instead of returning a `PShape` obejct and using `@draw_on_return`