### PR TITLE
Fix exceptions shown when closing canvas

### DIFF
--- a/p5/sketch/Vispy2DRenderer/base.py
+++ b/p5/sketch/Vispy2DRenderer/base.py
@@ -147,7 +147,7 @@ class VispySketch(app.Canvas):
         self._save_flag = True
 
     def on_close(self, event):
-        exit()
+        app.quit()
 
     def on_draw(self, event):
         pass

--- a/p5/sketch/userspace.py
+++ b/p5/sketch/userspace.py
@@ -22,6 +22,7 @@ import __main__
 import math
 import numpy as np
 import builtins
+import sys
 import time
 from functools import wraps
 
@@ -259,7 +260,7 @@ def exit(*args, **kwargs):
             from vispy import app
             p5.sketch.show(visible=False)
             app.quit()
-    p5.exit(*args, **kwargs)
+    sys.exit(*args, **kwargs)
 
 
 def no_cursor():


### PR DESCRIPTION
Fixes #150 and additionally prevents a SystemExit exception being thrown/reported that is anyways ignored.

`p5.exit()` documentation mentions that it forwards args
to the builtin `exit()`, so do that instead of calling
the non-existing `p5.core.p5.exit()` function. (Or prevent
a recursive call that by exit ended up calling a
non-existant function.

Do not call `p5.exit()` in on_close: exit() will throw a SystemExit
exception which will be cought by vispy, reported and ignored.
Since the windows has gone away we only need to quit the
running application for a normal exit.