### PR TITLE
Enable pylint for the entire p5 package

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -20,4 +20,4 @@ jobs:
           pip install -r requirements.txt
       - name: Run pylint
         run: |
-          pylint --disable=I --disable=W --disable=C --disable=R `find .  -path ./profiling -prune -false -o -name '*.py'`
+          pylint --disable=I --disable=W --disable=C --disable=R p5


### PR DESCRIPTION
The newest dependabot commit is failing pylint because `Module 'builtins' has no 'start_time' member`.
Running pylint on the whole package will hopefully give pylint enough context to recognize `start_time`.