### PR TITLE
Reapply #308 but return np.array instead of list

### DIFF
--- a/p5/sketch/Vispy2DRenderer/openglrenderer.py
+++ b/p5/sketch/Vispy2DRenderer/openglrenderer.py
@@ -351,5 +351,10 @@ class OpenGLRenderer(ABC):
         self.fbuffer.delete()
 
     def _transform_vertices(self, vertices, local_matrix, global_matrix):
-        return np.dot(np.dot(vertices, local_matrix.T), global_matrix.T)[:, :3]
-
+        """Applies `local_matrix` then `global_matrix` to `vertices`
+        """
+        product = np.dot(np.dot(vertices, local_matrix.T), global_matrix.T)
+        # dehomogenize coordinates
+        # need np.newaxis to broadcast the vector because each row represents a vertex
+        dehomogenized = product / product[:,3][:,np.newaxis]
+        return dehomogenized[:,:3] # Return the first three rows of the result


### PR DESCRIPTION
As @tushar5526 discovered in #318, #308 broke the 3D pipeline, so it was temporarily reverted.
The problem is that the return value of `_transform_vertices` is not of type `np.array` when some functions expected it to be. This change fixes that while also rewriting the logic to use numpy native functions so it's more efficient.