### PR TITLE
Prevent gh-action from running twice on new PR

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,6 +1,12 @@
 name: Run pylint
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,12 @@
 name: Run pytest
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build:

--- a/.github/workflows/sanityTesting.yml
+++ b/.github/workflows/sanityTesting.yml
@@ -1,6 +1,12 @@
 name: Run sanity tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build:


### PR DESCRIPTION
On trigger exisiting Github Actions on PR against master or pushes in master.
This avoids the problem of the actions being run twice in a new PR.
