### PR TITLE
Update minimum python version in tests

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.6
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.6
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/sanityTesting.yml
+++ b/.github/workflows/sanityTesting.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.6
       - name: Install dependencies
         run: |
           sudo apt-get install python-opengl libglfw3 python3-wheel -y

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
     package_dir={'p5': 'p5'},
     include_package_data=True,
 
-    setup_requires=['numpy'],
     install_requires=requires,
     python_requires='>=3.6',
 


### PR DESCRIPTION
Thanks to @jeremydouglass who spotted that the automated tests use a python version higher than the minimally supported one, this PR updates the tests to use Python 3.6.