### PR TITLE
Move contents of initialize_renderer to __init__

### DIFF
--- a/p5/sketch/Vispy2DRenderer/base.py
+++ b/p5/sketch/Vispy2DRenderer/base.py
@@ -86,6 +86,7 @@ class VispySketch(app.Canvas):
         self._save_fname = 'screen'
         self._save_flag = False
 
+        p5.renderer.reset_view()
         p5.renderer.clear()
 
     def on_timer(self, event):

--- a/p5/sketch/Vispy2DRenderer/base.py
+++ b/p5/sketch/Vispy2DRenderer/base.py
@@ -86,7 +86,6 @@ class VispySketch(app.Canvas):
         self._save_fname = 'screen'
         self._save_flag = False
 
-        p5.renderer.initialize_renderer()
         p5.renderer.clear()
 
     def on_timer(self, event):

--- a/p5/sketch/Vispy2DRenderer/openglrenderer.py
+++ b/p5/sketch/Vispy2DRenderer/openglrenderer.py
@@ -235,15 +235,32 @@ class Style:
 
 class OpenGLRenderer(ABC):
     def __init__(self, src_fbuffer, src_default):
-        self.default_prog = None
-        self.fbuffer_prog = None
+        self.fbuffer_prog = Program(src_fbuffer.vert, src_fbuffer.frag)
+        self.default_prog = Program(src_default.vert, src_default.frag)
 
-        self.fbuffer = None
+        self.fbuffer = FrameBuffer()
         self.fbuffer_tex_front = None
         self.fbuffer_tex_back = None
 
-        self.vertex_buffer = None
-        self.index_buffer = None
+        vertices = np.array([[-1.0, -1.0],
+                             [+1.0, -1.0],
+                             [-1.0, +1.0],
+                             [+1.0, +1.0]],
+                            np.float32)
+        texcoords = np.array([[0.0, 0.0],
+                              [1.0, 0.0],
+                              [0.0, 1.0],
+                              [1.0, 1.0]],
+                             dtype=np.float32)
+
+        self.fbuf_vertices = VertexBuffer(data=vertices)
+        self.fbuf_texcoords = VertexBuffer(data=texcoords)
+
+        self.fbuffer_prog['texcoord'] = self.fbuf_texcoords
+        self.fbuffer_prog['position'] = self.fbuf_vertices
+
+        self.vertex_buffer = VertexBuffer()
+        self.index_buffer = IndexBuffer()
 
         # Renderer Globals: STYLE/MATERIAL PROPERTIES
         #
@@ -265,32 +282,6 @@ class OpenGLRenderer(ABC):
         # Renderer Globals: RENDERING
         self.draw_queue = []
 
-        # Shaders
-        self.fbuffer_prog = Program(src_fbuffer.vert, src_fbuffer.frag)
-        self.default_prog = Program(src_default.vert, src_default.frag)
-
-    def initialize_renderer(self):
-        self.fbuffer = FrameBuffer()
-
-        vertices = np.array([[-1.0, -1.0],
-                             [+1.0, -1.0],
-                             [-1.0, +1.0],
-                             [+1.0, +1.0]],
-                            np.float32)
-        texcoords = np.array([[0.0, 0.0],
-                              [1.0, 0.0],
-                              [0.0, 1.0],
-                              [1.0, 1.0]],
-                             dtype=np.float32)
-
-        self.fbuf_vertices = VertexBuffer(data=vertices)
-        self.fbuf_texcoords = VertexBuffer(data=texcoords)
-
-        self.fbuffer_prog['texcoord'] = self.fbuf_texcoords
-        self.fbuffer_prog['position'] = self.fbuf_vertices
-
-        self.vertex_buffer = VertexBuffer()
-        self.index_buffer = IndexBuffer()
 
     def render_default(self, draw_type, draw_queue):
         # 1. Get the maximum number of vertices persent in the shapes

--- a/p5/sketch/Vispy2DRenderer/renderer2d.py
+++ b/p5/sketch/Vispy2DRenderer/renderer2d.py
@@ -39,15 +39,10 @@ from .shape import PShape, Arc
 class VispyRenderer2D(OpenGLRenderer):
     def __init__(self):
         super().__init__(src_fbuffer, src_default)
-        self.texture_prog = None
-        self.line_prog = None
-        self.modelview_matrix = np.identity(4)
-
-    def initialize_renderer(self):
-        super().initialize_renderer()
         self.texture_prog = Program(src_texture.vert, src_texture.frag)
         self.texture_prog['texcoord'] = self.fbuf_texcoords
-        self.reset_view()
+        self.line_prog = None
+        self.modelview_matrix = np.identity(4)
 
     def reset_view(self):
         self.viewport = (

--- a/p5/sketch/Vispy3DRenderer/renderer3d.py
+++ b/p5/sketch/Vispy3DRenderer/renderer3d.py
@@ -112,10 +112,6 @@ class Renderer3D(OpenGLRenderer):
         self.curr_linear_falloff, self.curr_quadratic_falloff, self.curr_constant_falloff = 0.0, 0.0, 0.0
         self.light_specular = np.array([0.0] * 3)
 
-    def initialize_renderer(self):
-        super().initialize_renderer()
-        self.reset_view()
-
     def reset_view(self):
         self.viewport = (
             0,


### PR DESCRIPTION
Merge `initialize_renderer` with `__init__` for the renderer classes, since in the current implementation there's no information needed by `initialize_renderer` that's not available at the time of `__init__`.

Also fixes #340 and #333 since `texture_prog` now exists when `_on_resize` is called.