### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ freetype-py==2.1.0.post1
 glfw==1.11.2
 numpy==1.18.5
 Pillow==8.2.0
-vispy==0.6.4
-PyOpenGL==3.1.5
+vispy==0.10.0
 PyOpenGL-accelerate==3.1.5
+PyOpenGL==3.1.6
 requests==2.22.0
 dataclasses;python_version=="3.6"


### PR DESCRIPTION
The package installation failed on MacOS 12.3.1, Python 3.9.13. Updating some of the packages seemed to have fixed the issue.