### PR TITLE
Update MANIFEST to include requirements.txt and fix the name of LICENSE file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
-include LICENSE.txt
+include LICENSE
 recursive-include p5/sketch/Vispy2DRenderer/shaders *
 recursive-include p5/sketch/Vispy3DRenderer/shaders *
+include requirements.txt


### PR DESCRIPTION
The build was failing due to `requirements.txt` not being found. We had to manually include it in the `MANIFEST.in`

Both `tar ball` and `wheels` are building fine now