### PR TITLE
Use framebuffer size to create surface for retina displays

### DIFF
--- a/p5/sketch/Skia2DRenderer/base.py
+++ b/p5/sketch/Skia2DRenderer/base.py
@@ -81,13 +81,23 @@ class SkiaSketch:
         glfw.make_context_current(window)
         return window
 
-    def skia_surface(self, window, size):
+    def skia_surface(self, window=None, size=None):
         self.context = skia.GrDirectContext.MakeGL()
+        if size:
+            width, height = size
+        elif window:
+            width, height = glfw.get_framebuffer_size(window)
+        else:
+            raise ValueError(
+                "Both window and size can't be None, This is probably an error within p5 "
+                "instead of the sketch"
+            )
         backend_render_target = skia.GrBackendRenderTarget(
-            *size,
+            width,
+            height,
             0,  # sampleCnt
             0,  # stencilBits
-            skia.GrGLFramebufferInfo(0, GL.GL_RGBA8)
+            skia.GrGLFramebufferInfo(0, GL.GL_RGBA8),
         )
         surface = skia.Surface.MakeFromBackendRenderTarget(
             self.context,

--- a/p5/sketch/Skia2DRenderer/base.py
+++ b/p5/sketch/Skia2DRenderer/base.py
@@ -89,8 +89,7 @@ class SkiaSketch:
             width, height = glfw.get_framebuffer_size(window)
         else:
             raise ValueError(
-                "Both window and size can't be None, This is probably an error within p5 "
-                "instead of the sketch"
+                "Both window and size can't be None, This is probably an error within p5 instead of the sketch"
             )
         backend_render_target = skia.GrBackendRenderTarget(
             width,

--- a/p5/sketch/Skia2DRenderer/renderer2d.py
+++ b/p5/sketch/Skia2DRenderer/renderer2d.py
@@ -168,12 +168,16 @@ class SkiaRenderer:
                 self.paint.setStyle(skia.Paint.kStroke_Style)
                 self.paint.setColor(skia.Color4f(*self.style.stroke_color))
                 self.paint.setStrokeWidth(self.style.stroke_weight)
-                self.canvas.drawSimpleText(text, nx, ny, self.style.text_font, self.paint)
+                self.canvas.drawSimpleText(
+                    text, nx, ny, self.style.text_font, self.paint
+                )
 
             if self.style.fill_enabled:
                 self.paint.setStyle(skia.Paint.kFill_Style)
                 self.paint.setColor(skia.Color4f(*self.style.fill_color))
-                self.canvas.drawSimpleText(text, nx, ny, self.style.text_font, self.paint)
+                self.canvas.drawSimpleText(
+                    text, nx, ny, self.style.text_font, self.paint
+                )
 
             # If there are more text, add the previous text's height and text_leading to y
             y += self.style.text_leading + text_height


### PR DESCRIPTION
Always use frame buffer size to create a skia surface to handle retina displays as well, this function will also serve as a utility function for PGraphics object so we need 'size' as well, as window is None in that case.