### PR TITLE
Added code formatting using black through a Github Action

### DIFF
--- a/.github/workflows/blackFormatter.yml
+++ b/.github/workflows/blackFormatter.yml
@@ -1,0 +1,25 @@
+name: black-action
+on: [push, pull_request]
+jobs:
+  linter_name:
+    name: runner / black
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check files using the black formatter
+        uses: rickstaa/action-black@v1
+        id: action_black
+        with:
+          black_args: "."
+      - name: Create Pull Request
+        if: steps.action_black.outputs.is_formatted == 'true'
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "Format Python code with psf/black push"
+          commit-message: ":art: Python code fromated with psf/black"
+          body: |
+            There appear to be some python formatting errors in ${{ github.sha }}. This pull request
+            uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.
+          base: ${{ github.head_ref }} # Creates pull request onto pull request or commit branch
+          branch: actions/black


### PR DESCRIPTION
Ref to Issue: #358 

I added a Github action which Runs on After a PR merge and Check if it is formatted with PEP standard and Formatted it with black formatter, and Make a PR with formatted code.

