### PR TITLE
Update requirements for 3.10

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/sanityTesting.yml
+++ b/.github/workflows/sanityTesting.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ '3.7', '3.8', '3.9' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy
 Pillow==9.0.1
 vispy==0.10.0
 PyOpenGL-accelerate@git+https://github.com/mcfletch/pyopengl.git@227f9c66976d9f5dadf62b9a97e6beaec84831ca#subdirectory=accelerate
-PyOpenGL==3.1.5
+PyOpenGL==3.1.6
 requests>=2.25.0
 dataclasses;python_version=="3.6"
 skia-python>=85.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,11 @@ glfw==1.11.2
 numpy
 Pillow==9.0.1
 vispy==0.10.0
-PyOpenGL-accelerate==3.1.5
-PyOpenGL==3.1.6
+PyOpenGL-accelerate==3.1.5; python_version >= '3.7' and python_version <= '3.9'
+PyOpenGL-accelerate==3.1.6; sys_platform == 'win32'
+PyOpenGL-accelerate @git+https://github.com/mcfletch/pyopengl.git@227f9c66976d9f5dadf62b9a97e6beaec84831ca#subdirectory=accelerate; python_version=='3.10'
+
+PyOpenGL==3.1.5
 requests>=2.25.0
 dataclasses;python_version=="3.6"
 skia-python>=85.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ glfw==1.11.2
 numpy
 Pillow==9.0.1
 vispy==0.10.0
-PyOpenGL-accelerate==3.1.6; sys_platform == 'win32'
 PyOpenGL-accelerate@git+https://github.com/mcfletch/pyopengl.git@227f9c66976d9f5dadf62b9a97e6beaec84831ca#subdirectory=accelerate
 PyOpenGL==3.1.5
 requests>=2.25.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,8 @@ glfw==1.11.2
 numpy
 Pillow==9.0.1
 vispy==0.10.0
-PyOpenGL-accelerate==3.1.5; python_version >= '3.7' and python_version <= '3.9'
 PyOpenGL-accelerate==3.1.6; sys_platform == 'win32'
-PyOpenGL-accelerate @git+https://github.com/mcfletch/pyopengl.git@227f9c66976d9f5dadf62b9a97e6beaec84831ca#subdirectory=accelerate; python_version=='3.10'
-
+PyOpenGL-accelerate@git+https://github.com/mcfletch/pyopengl.git@227f9c66976d9f5dadf62b9a97e6beaec84831ca#subdirectory=accelerate
 PyOpenGL==3.1.5
 requests>=2.25.0
 dataclasses;python_version=="3.6"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 freetype-py==2.1.0.post1
 glfw==1.11.2
-numpy>=1.18.5
+numpy
 Pillow==9.0.1
 vispy==0.10.0
 PyOpenGL-accelerate==3.1.5


### PR DESCRIPTION
Closes #396

I think using the latest version of NumPy available for that specific python version would work fine instead of a specific version for all python versions. 

PyOpenGl's 3.1.6 works well on Ubuntu. Its need to be tested for windows and mac