### PR TITLE
Use frame buffer value to create initial surface

### DIFF
--- a/p5/sketch/Skia2DRenderer/base.py
+++ b/p5/sketch/Skia2DRenderer/base.py
@@ -108,11 +108,8 @@ class SkiaSketch:
 
     # create a new surface everytime
     def create_surface(self, size=None):
-        if not size:
-            size = self._size
-        self._size = size
-        builtins.width, builtins.height = size
         self.surface = self.skia_surface(self.window, size)
+        builtins.width, builtins.height = glfw.get_window_size(self.window)
         self.canvas = self.surface.getCanvas()
         p5.renderer.initialize_renderer(self.canvas, self.paint, self.path)
 


### PR DESCRIPTION
Related to #399 
Hey @ziyaointl, I think I was not initializing the frame buffers properly. It should be fixed now. 

Can you test this and also test the behaviour when we resize manually using mouse and dragging the sides of the window on MAC ?

Explanation of Changes: When no size is specified, use the frame_buffer size to create surface. 
 