### PR TITLE
Check is user has defined preload before use

### DIFF
--- a/p5/sketch/userspace.py
+++ b/p5/sketch/userspace.py
@@ -156,7 +156,7 @@ def run(
     # get the user-defined setup(), draw(), preload() and handler functions.
     if sketch_preload is not None:
         preload_method = sketch_preload
-    elif hasattr(__main__, "setup"):
+    elif hasattr(__main__, "preload"):
         preload_method = __main__.preload
     else:
         preload_method = preload


### PR DESCRIPTION
The current code checks if "setup" is defined by the user before loading "preload". I suspect this is a simple copy-paste mistake from a couple of lines later, where the code checks if "setup" is defined before loading "setup".

This is a tiny fix.