### PR TITLE
Fix for unordinary behavior of size() in setup() for skia

### DIFF
--- a/p5/sketch/Skia2DRenderer/base.py
+++ b/p5/sketch/Skia2DRenderer/base.py
@@ -205,7 +205,7 @@ class SkiaSketch:
         Values of width and height may not be equal to the actual window's width and height
         in Retina Display
         """
-
+        self.resized = False
         # Callback handler for frame buffer resize events
         builtins.pixel_x_density = width / self.size[0]
         builtins.pixel_y_density = height / self.size[1]
@@ -213,6 +213,7 @@ class SkiaSketch:
 
         GL.glViewport(0, 0, width, height)
         self.create_surface(size=(width, height))
+        self.setup_method()
         # with self.surface as self.canvas:
         #     # redraw on the canvas/ ( new frame buffer ) after resizing
         #     # and do not rewind/clear the path

--- a/p5/sketch/Skia2DRenderer/base.py
+++ b/p5/sketch/Skia2DRenderer/base.py
@@ -5,6 +5,7 @@ import contextlib, glfw, skia
 from OpenGL import GL
 from time import time
 
+import copy
 from ..events import handler_names
 from .handlers import *
 from .util import *
@@ -214,11 +215,13 @@ class SkiaSketch:
         # To take in account the contents of the last surface.
         old_image = self.surface.makeImageSnapshot()
         old_image = old_image.resize(old_image.width(),old_image.height())
+        old_style = copy.copy(p5.renderer.style)
 
         GL.glViewport(0, 0, width, height)
         self.create_surface(size=(width, height))
         self.setup_method()
         
+        p5.renderer.style = old_style
         # Renders the content of the last surface to the newly created
         with self.surface as self.canvas:
             self.canvas.drawImage(old_image,0,0)

--- a/p5/sketch/Skia2DRenderer/base.py
+++ b/p5/sketch/Skia2DRenderer/base.py
@@ -215,7 +215,7 @@ class SkiaSketch:
         # To take in account the contents of the last surface.
         old_image = self.surface.makeImageSnapshot()
         old_image = old_image.resize(old_image.width(),old_image.height())
-        old_style = copy.copy(p5.renderer.style)
+        old_style = copy.deepcopy(p5.renderer.style)
 
         GL.glViewport(0, 0, width, height)
         self.create_surface(size=(width, height))

--- a/p5/sketch/Skia2DRenderer/base.py
+++ b/p5/sketch/Skia2DRenderer/base.py
@@ -206,30 +206,33 @@ class SkiaSketch:
         Values of width and height may not be equal to the actual window's width and height
         in Retina Display
         """
-        self.resized = False
         # Callback handler for frame buffer resize events
+
+        self.resized = False
         builtins.pixel_x_density = width / self.size[0]
         builtins.pixel_y_density = height / self.size[1]
         self.pixel_density = width * height // (self.size[0] * self.size[1])
 
-        # To take in account the contents of the last surface.
+        # Creates an Image of current surface and a copy of current style configurations
+        # For the purpose of handling setup_method() re-call 
+        # Ref: Issue #419
         old_image = self.surface.makeImageSnapshot()
-        old_image = old_image.resize(old_image.width(),old_image.height())
+        old_image = old_image.resize(old_image.width(), old_image.height())
         old_style = copy.deepcopy(p5.renderer.style)
 
         GL.glViewport(0, 0, width, height)
         self.create_surface(size=(width, height))
         self.setup_method()
-        
-        p5.renderer.style = old_style
-        # Renders the content of the last surface to the newly created
-        with self.surface as self.canvas:
-            self.canvas.drawImage(old_image,0,0)
 
-        #     # redraw on the canvas/ ( new frame buffer ) after resizing
-        #     # and do not rewind/clear the path
+        # Redraws Image on the canvas/ new frame buffer
+        # Previously stored style configurations are restored for
+        # discarding setup_method() style changes
+        p5.renderer.style = old_style
+        with self.surface as self.canvas:
+            self.canvas.drawImage(old_image, 0, 0)
 
         # Tell the program, we have resized the frame buffer
+        # and do not rewind/clear the path
         # Restart the rendering again
         self.resized = True
 

--- a/p5/sketch/Skia2DRenderer/base.py
+++ b/p5/sketch/Skia2DRenderer/base.py
@@ -211,10 +211,18 @@ class SkiaSketch:
         builtins.pixel_y_density = height / self.size[1]
         self.pixel_density = width * height // (self.size[0] * self.size[1])
 
+        # To take in account the contents of the last surface.
+        old_image = self.surface.makeImageSnapshot()
+        old_image = old_image.resize(old_image.width(),old_image.height())
+
         GL.glViewport(0, 0, width, height)
         self.create_surface(size=(width, height))
         self.setup_method()
-        # with self.surface as self.canvas:
+        
+        # Renders the content of the last surface to the newly created
+        with self.surface as self.canvas:
+            self.canvas.drawImage(old_image,0,0)
+
         #     # redraw on the canvas/ ( new frame buffer ) after resizing
         #     # and do not rewind/clear the path
 

--- a/p5/sketch/userspace.py
+++ b/p5/sketch/userspace.py
@@ -254,6 +254,10 @@ def size(width, height):
     :type height: int
 
     """
+
+    # return with no change in size when called from frame buffer resize callback
+    # this is to handle setup function re-call during resize
+    # Ref: Issue #419
     if(builtins.current_renderer == "skia" and not p5.sketch.resized):
         return
 

--- a/p5/sketch/userspace.py
+++ b/p5/sketch/userspace.py
@@ -254,6 +254,9 @@ def size(width, height):
     :type height: int
 
     """
+    if(builtins.current_renderer == "skia" and not p5.sketch.resized):
+        return
+
     builtins.width = int(width)
     builtins.height = int(height)
     p5.sketch.size = (builtins.width, builtins.height)


### PR DESCRIPTION
This is a partial "fix" for #419 particularly for Skia Renderer. Related to #420

What I found tracing the calls are following:
- This issue is due to how `GLFW` handles `window resize events`.
- Whenever a glfw window is resized by `size()` or manually by the user, it triggers a window resize event in the `glfw event queue`, this event is inherently asynchronous, so this does not take place instantly, but when it does, a callback function is called. The callback function is assigned by [self.assign_callbacks()](https://github.com/p5py/p5/blob/4c63a4f72785d084f9dffe2ee99fe37a60fe373d/p5/sketch/Skia2DRenderer/base.py#L158) in the `start()` of SkiaSketch.
- We assign [frame_buffer_resize_callback_handler()](https://github.com/p5py/p5/blob/4c63a4f72785d084f9dffe2ee99fe37a60fe373d/p5/sketch/Skia2DRenderer/base.py#L202) as a callback for such events.
- In this callback, for the changed window size, we create a `new surface` with the new dimensions by [self.create_surface(size=(width, height)).](https://github.com/p5py/p5/blob/4c63a4f72785d084f9dffe2ee99fe37a60fe373d/p5/sketch/Skia2DRenderer/base.py#L215)
#### **Now here is the issue:**
  - This newly created surface which is clear and black is the new `self.surface` and is subsequently displayed on the window by the `main_loop()`, this is the reason why anything drawn in `setup()` with `size()` is not visible because a **new surface is created above, everytime is size() is called.**

### Potential Fix:
- Re-render all the contents of `setup()` on the new surface.

This is exactly what I am doing here, I have done 2 changes:
- Called `setup_method()` again after the window is resized and new surface created, so that all the renders of the previous surface is again rendered on the new surface.
- Calling `setup_method()` again, posed the problem of recurrent calling of `size()`, to not let that happen, I have added a simple check in [userspace.py/size()](https://github.com/devAyushDubey/p5/blob/cb18c379df87a4f5c69b5b925e92996752dbd06f/p5/sketch/userspace.py#L257) that ensures that, **`size()` is not called in the re-rendering call**.
- This check together with the added `self.resized = False` in [frame_buffer_resize_callback_handler()](https://github.com/devAyushDubey/p5/blob/cb18c379df87a4f5c69b5b925e92996752dbd06f/p5/sketch/Skia2DRenderer/base.py#L208) also facilitates manual resizing of window and works perfectly fine.

### Now
```python
from p5 import *

def setup():
    size(512,512)
    background(220)
    circle(100,100,50)

run(renderer="skia")
```
![Screenshot from 2023-02-20 11-12-19](https://user-images.githubusercontent.com/33064931/220023646-44881e4f-01e2-44f9-a382-8f4adb6f1b82.png)
**With draw()**
![Screenshot from 2023-02-20 11-14-27](https://user-images.githubusercontent.com/33064931/220023802-dbcf852a-33ea-4c86-90d3-d5aa931d4708.png)
**Manual Resizing:**
![Screencast from 20-02-23 11_16_01 AM IST (1)](https://user-images.githubusercontent.com/33064931/220023999-5d2bbf0c-2ba7-44a8-8993-95cc2d39f765.gif)
