### PR TITLE
Fixes #372: calling size() in setup() producing weird behavior

### DIFF
--- a/p5/sketch/userspace.py
+++ b/p5/sketch/userspace.py
@@ -266,6 +266,8 @@ def size(width, height):
         )
         p5.renderer.camera_pos = eye
 
+    p5.sketch.poll_events()
+
 
 def no_loop():
     """Stop draw() from being continuously called.

--- a/p5/sketch/userspace.py
+++ b/p5/sketch/userspace.py
@@ -266,7 +266,8 @@ def size(width, height):
         )
         p5.renderer.camera_pos = eye
 
-    p5.sketch.poll_events()
+    if builtins.current_renderer == "skia":
+        p5.sketch.poll_events()
 
 
 def no_loop():


### PR DESCRIPTION
Polling for events within the size() function right after the size has been changed will make glfw trigger the window resize event right then and there.
This will create a new surface right after the call to size(), so that any graphics drawn from this point on in size() will be preserved.

Another issue still remains. The one where the buffers are not being swapped properly. Once a sketch is started, after a few seconds, the buffer being rendered to the window completely changes. After a few more seconds, the old buffer is rendered again, and this continues indefinitely.

I highly suspect that this is the same issue described by @tushar5526 here: https://github.com/p5py/p5/pull/420#issuecomment-1437169760

As a result of this issue, the fix proposed in this PR will only be seen when this "buffer change" takes place. To confirm this:
- Run an example program:
  ```
  from p5 import *
  
  def setup():
      size(512, 256)
      background(220)
  
  def draw():
      circle(mouse_x, mouse_y, 50)
  
  run(renderer='skia')
  ```
- Wait for a few seconds. The first "buffer change" occurs. This is when you'll notice that the `background(220)` has taken effect, but in this other buffer.
- And inevitably, the "buffer change" occurs again and you're back to the first buffer.

Demonstration:

https://user-images.githubusercontent.com/54534811/220284623-d0d8a04a-b00a-4db1-8e5d-20a88801dd66.mov

In the current master branch (without the fix in this PR), the `background(220)` call would not have taken effect in any buffer. I will be investigating the "buffer change" issue further.