### PR TITLE
fix args unpacking for corners mode

### DIFF
--- a/docs/guides/vscode.rst
+++ b/docs/guides/vscode.rst
@@ -15,11 +15,11 @@ Setup
 3. In the ``.vscode`` directory create a file called ``settings.json``
 4. In that file copy and paste all of these json settings:
 
-.. code:: 
+.. code::
 
     {
-        "python.linting.pylintArgs": [
-            "--disable", "E0102", 
+        "pylint.args": [
+            "--disable", "E0102",
             "--disable", "C0111",
             "--disable", "W0401",
             "--disable", "C0304",

--- a/p5/core/primitives.py
+++ b/p5/core/primitives.py
@@ -602,8 +602,7 @@ def rect(*args, mode: Optional[str] = None):
             height = 2 * half_height
         elif mode == "CORNERS":
             corner = Point(*coordinate)
-            (corner_2,) = args
-            corner_2 = Point(*corner_2)
+            corner_2 = Point(*args)
             width = corner_2.x - corner.x
             height = corner_2.y - corner.y
         else:

--- a/p5/core/primitives.py
+++ b/p5/core/primitives.py
@@ -562,7 +562,7 @@ def rect(*args, mode: Optional[str] = None):
     :param args: For modes'CORNER' or 'CENTER' this has the form
         (width, height); for the 'RADIUS' this has the form
         (half_width, half_height); and for the 'CORNERS' mode, args
-        should be the corner opposite to `coordinate`.
+        should be two int values x, y - the coords of corner opposite to `coordinate`.
 
     :type: tuple
 


### PR DESCRIPTION
Fixing issue #438 
Wrong unpacking of arguments for CORNERS mode.
Now supports both:
```
rectMode(CORNERS)
rect(100, 100, 200, 200)
```

and

```
rectMode(CORNERS)
rect((100, 100), 200, 200)
```

Example from the bug issue:

<img width="722" alt="Screenshot 2023-09-30 at 18 44 26" src="https://github.com/p5py/p5/assets/17104239/897f0622-dccb-4b64-9175-8f387fe68cd5">
<img width="722" alt="Screenshot 2023-09-30 at 18 45 06" src="https://github.com/p5py/p5/assets/17104239/00d6353c-6436-4674-8d65-cc3caa7464c2">
