### PR TITLE
fix jitter behaviour of skia due to double buffers swapping

### DIFF
--- a/p5/sketch/Skia2DRenderer/base.py
+++ b/p5/sketch/Skia2DRenderer/base.py
@@ -183,8 +183,6 @@ class SkiaSketch:
         # on a different thread
         glfw.set_window_size(self.window, *self.size)
 
-
-
     def poll_events(self):
         glfw.poll_events()
         if glfw.get_key(

--- a/p5/sketch/Skia2DRenderer/handlers.py
+++ b/p5/sketch/Skia2DRenderer/handlers.py
@@ -225,7 +225,7 @@ def on_close(window):
 
 
 def _adjust_mouse_pos(window, pos):
-    if platform.system() != 'Darwin':
+    if platform.system() != "Darwin":
         return pos
     glfw.get_window_content_scale(window)
     pos_x, pos_y = pos

--- a/p5/sketch/Skia2DRenderer/handlers.py
+++ b/p5/sketch/Skia2DRenderer/handlers.py
@@ -130,8 +130,7 @@ input_state = InputState([], 0, [], {})
 
 
 def on_mouse_button(window, button, action, mod):
-    pos = glfw.get_cursor_pos(window)
-
+    pos = _adjust_mouse_pos(window, glfw.get_cursor_pos(window))
     if button < 3:
         button = BUTTONMAP.get(button, 0)
 
@@ -152,7 +151,7 @@ def on_mouse_button(window, button, action, mod):
 
 
 def on_mouse_scroll(window, x_off, y_off):
-    pos = glfw.get_cursor_pos(window)
+    pos = _adjust_mouse_pos(glfw.get_cursor_pos(window))
     delta = (float(x_off), float(y_off))
     event = PseudoMouseEvent(pos=pos, delta=delta, modifiers=input_state.modifiers)
     mev = MouseEvent(event, active=builtins.mouse_is_pressed)
@@ -161,7 +160,9 @@ def on_mouse_scroll(window, x_off, y_off):
 
 
 def on_mouse_motion(window, x, y):
-    event = PseudoMouseEvent(pos=(x, y), modifiers=input_state.modifiers)
+    event = PseudoMouseEvent(
+        _adjust_mouse_pos(window, (x, y)), modifiers=input_state.modifiers
+    )
     mev = MouseEvent(event, active=builtins.mouse_is_pressed)
 
     # Queue a 'mouse_dragged` or `mouse_moved` event, not both similar to p5.js
@@ -220,3 +221,10 @@ def on_window_focus(window, focused):
 
 def on_close(window):
     pass
+
+
+def _adjust_mouse_pos(window, pos):
+    glfw.get_window_content_scale(window)
+    pos_x, pos_y = pos
+    mul_x, mul_y = glfw.get_window_content_scale(window)
+    return pos_x * mul_x, pos_y * mul_y

--- a/p5/sketch/Skia2DRenderer/handlers.py
+++ b/p5/sketch/Skia2DRenderer/handlers.py
@@ -4,6 +4,7 @@ This file contains the handlers needed for glfw event handling
 
 
 import builtins
+import platform
 import glfw
 from p5.core import p5
 from p5.sketch.events import KeyEvent, MouseEvent
@@ -224,6 +225,8 @@ def on_close(window):
 
 
 def _adjust_mouse_pos(window, pos):
+    if platform.system() != 'Darwin':
+        return pos
     glfw.get_window_content_scale(window)
     pos_x, pos_y = pos
     mul_x, mul_y = glfw.get_window_content_scale(window)

--- a/p5/sketch/Skia2DRenderer/handlers.py
+++ b/p5/sketch/Skia2DRenderer/handlers.py
@@ -151,7 +151,7 @@ def on_mouse_button(window, button, action, mod):
 
 
 def on_mouse_scroll(window, x_off, y_off):
-    pos = _adjust_mouse_pos(glfw.get_cursor_pos(window))
+    pos = _adjust_mouse_pos(window, glfw.get_cursor_pos(window))
     delta = (float(x_off), float(y_off))
     event = PseudoMouseEvent(pos=pos, delta=delta, modifiers=input_state.modifiers)
     mev = MouseEvent(event, active=builtins.mouse_is_pressed)

--- a/p5/sketch/Skia2DRenderer/renderer2d.py
+++ b/p5/sketch/Skia2DRenderer/renderer2d.py
@@ -72,6 +72,15 @@ class SkiaRenderer:
         self.path = None
         self.curve_tightness = 0
         self.pimage = None
+        # used to store the surface state before swapping with secondary buffer
+        self._surface_image = None
+
+    # TODO: Optimise it using bitmap or pixmap
+    def _store_surface_state(self):
+        self._surface_image = self.canvas.getSurface().makeImageSnapshot()
+
+    def _restore_surface_state(self):
+        self.canvas.drawImage(self._surface_image, 0, 0)
 
     # Transforms functions
     def push_matrix(self):

--- a/p5/sketch/userspace.py
+++ b/p5/sketch/userspace.py
@@ -309,8 +309,7 @@ def exit():
     before exiting the sketch.
 
     """
-    if p5.sketch is not None and builtins.current_renderer == "vispy":
-        p5.sketch.exit()
+    p5.sketch.exit()
 
 
 def no_cursor():

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ glfw>=2.5.9
 numpy
 Pillow==9.0.1
 vispy==0.10.0
-PyOpenGL-accelerate==3.1.6
+PyOpenGL-accelerate==3.1.7
 PyOpenGL==3.1.6
 requests>=2.25.0
 dataclasses;python_version=="3.6"


### PR DESCRIPTION
Realted to #424 #425

The jittery behaviour and errors with skia were due to wrong rendering logic. GLFW uses a double buffer swapping technique to render graphics and our logic was only running the new commands and the previous state was getting lost after buffer swaps. 

Currently did a hacky solution to fix it for now (tested on MacOS)

- We are currently storing the state of `surface` in an image before flushing and swapping the buffers. The state is then restored before the start of the next frame. 
- Another solution would be to mimic all the `path` in Canvas, which I don't think is easy to do with the current code structure. 

TODO: to switch to using `bitmap` or `pixmap` to store state

This PR also fixes the errors of wrong mouse position in retina displays on MAC. 

