### PR TITLE
Configure pre-commit to run black, flake8, and Isort before commits.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,4 +13,4 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
-        
+        args: ["--profile=black"] # <-- this one

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.11.0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+
+  # - repo: https://github.com/pytest-dev/pytest
+  #   rev: 7.4.1  
+  #   hooks:
+  #     - id: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,8 @@ repos:
     hooks:
       - id: flake8
 
-  # - repo: https://github.com/pytest-dev/pytest
-  #   rev: 7.4.1  
-  #   hooks:
-  #     - id: pytest
+  - repo: https://github.com/pycqa/isort 
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        


### PR DESCRIPTION
Hi @tushar5526 sir,


I've just submitted a pull request that aims to set up pre-commit to run black, flake8,isort before commits. I would greatly appreciate it if you could take some time to review it.

### Details:
- *Black:  :* code formatter
- *Flake8:* Checks Python code against standards
- *Isort:*  Organizes and sorts import statements

### Changes done:
- *Points for Review:*  .pre-commit-config.yaml file added
  
<img width="431" alt="Screenshot 2023-12-05 at 1 09 56 PM" src="https://github.com/p5py/p5/assets/103623274/4de5ff41-fafd-42c7-aa3d-1c1def74356a">

### Expected Behaviour:


https://github.com/p5py/p5/assets/103623274/f64dd9d5-eb58-4b74-af5d-da3661423e4e



Your suggestions and feedback would be extremely beneficial in ensuring the quality and functioning of these update
