### PR TITLE
Incorrect documentation example input title

### DIFF
--- a/docs/examples/input/mouse functions.rst
+++ b/docs/examples/input/mouse functions.rst
@@ -1,5 +1,5 @@
 ********
-Mouse 1D
+Mouse Functions
 ********
 
 .. raw:: html


### PR DESCRIPTION
The title "Mouse 1D" was duplicated instead of using "Mouse Functions" as the title. The correct title is also confirmed by the URL. [https://p5.readthedocs.io/en/latest/examples/input/mouse%20functions.html](url)

# What it currently looks like:
![image](https://github.com/user-attachments/assets/b6039f30-f3e7-4eca-8f11-4be400fb063a)

# What it should look like:
![image](https://github.com/user-attachments/assets/fdcd4894-34c3-446c-8d8d-15c71e7f4eef)

