### PR TITLE
updated requirements

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 glfw>=2.5.9
 numpy
-Pillow==9.0.1
-vispy==0.10.0
-PyOpenGL-accelerate==3.1.7
-PyOpenGL==3.1.6
+Pillow==11.3.0
+vispy==0.15.2
+PyOpenGL-accelerate==3.1.10
+PyOpenGL==3.1.10
 requests>=2.25.0
 dataclasses;python_version=="3.6"
 skia-python>=85.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 glfw>=2.5.9
 numpy
-Pillow>=10.4.0
-vispy==0.10.0
+Pillow==11.3.0
+vispy==0.15.2
 PyOpenGL-accelerate==3.1.10
 PyOpenGL==3.1.10
 requests>=2.25.0

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     package_dir={"p5": "p5"},
     include_package_data=True,
     install_requires=requires,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
@@ -49,7 +49,6 @@ setup(
         "Topic :: Multimedia :: Graphics",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Updating
```
Pillow==11.3.0
vispy==0.15.2
PyOpenGL=3.1.10
PyOpenGL-accelerate=3.1.10
```
allows `p5py` to be installed on MacOS15 (m1 pro) Python3.13 without errors